### PR TITLE
Ajoute squelette d'application iOS ergonomique

### DIFF
--- a/ErgonomieApp/ErgonomieApp.swift
+++ b/ErgonomieApp/ErgonomieApp.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+@main
+struct ErgonomieApp: App {
+    @StateObject private var captureViewModel = CaptureViewModel()
+    @StateObject private var dashboardViewModel = DashboardViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            TabView {
+                CaptureScreen()
+                    .tabItem {
+                        Label("Capture", systemImage: "video")
+                    }
+                    .environmentObject(captureViewModel)
+                    .environmentObject(dashboardViewModel)
+
+                DashboardView()
+                    .tabItem {
+                        Label("Tableau de bord", systemImage: "waveform")
+                    }
+                    .environmentObject(dashboardViewModel)
+
+                ReportsView()
+                    .tabItem {
+                        Label("Rapports", systemImage: "doc.text")
+                    }
+                    .environmentObject(dashboardViewModel)
+            }
+        }
+    }
+}

--- a/ErgonomieApp/Models/JointType.swift
+++ b/ErgonomieApp/Models/JointType.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum JointType: String, CaseIterable, Codable, Comparable {
+    case head
+    case neck
+    case leftShoulder
+    case rightShoulder
+    case leftElbow
+    case rightElbow
+    case leftWrist
+    case rightWrist
+    case torso
+    case leftHip
+    case rightHip
+    case leftKnee
+    case rightKnee
+    case leftAnkle
+    case rightAnkle
+
+    static func < (lhs: JointType, rhs: JointType) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/ErgonomieApp/Models/PoseFrame.swift
+++ b/ErgonomieApp/Models/PoseFrame.swift
@@ -1,0 +1,33 @@
+import CoreGraphics
+import Foundation
+
+typealias NormalizedPoint = CGPoint
+
+struct PoseFrame: Identifiable, Codable {
+    let id = UUID()
+    let timestamp: Date
+    let jointPositions: [JointType: NormalizedPoint]
+    let jointAngles: [JointType: Double]
+    let repetitionEstimate: Double
+    let mostCriticalJoint: JointType?
+    let isoScore: Int
+
+    var jointConnections: [(JointType, JointType)] {
+        [
+            (.head, .neck),
+            (.neck, .torso),
+            (.torso, .leftShoulder),
+            (.torso, .rightShoulder),
+            (.leftShoulder, .leftElbow),
+            (.leftElbow, .leftWrist),
+            (.rightShoulder, .rightElbow),
+            (.rightElbow, .rightWrist),
+            (.torso, .leftHip),
+            (.leftHip, .leftKnee),
+            (.leftKnee, .leftAnkle),
+            (.torso, .rightHip),
+            (.rightHip, .rightKnee),
+            (.rightKnee, .rightAnkle)
+        ]
+    }
+}

--- a/ErgonomieApp/Models/PoseSession.swift
+++ b/ErgonomieApp/Models/PoseSession.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftUI
+
+struct PoseSession: Identifiable, Codable {
+    let id: UUID
+    let metadata: SessionMetadata
+    let frames: [PoseFrame]
+    let assessments: [JointAssessment]
+    let metrics: [PoseMetric]
+}
+
+struct SessionMetadata: Codable {
+    let date: Date
+    let taskName: String
+    let operatorName: String
+    let notes: String
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+struct PoseMetric: Identifiable, Codable {
+    let id = UUID()
+    let joint: JointType
+    let timestamp: Date
+    let value: Double
+}
+
+struct JointAssessment: Codable {
+    enum RiskLevel: String, Codable {
+        case low
+        case medium
+        case high
+
+        var description: String {
+            switch self {
+            case .low:
+                return "Faible"
+            case .medium:
+                return "Modéré"
+            case .high:
+                return "Élevé"
+            }
+        }
+
+        var iconName: String {
+            switch self {
+            case .low:
+                return "checkmark.circle"
+            case .medium:
+                return "exclamationmark.triangle"
+            case .high:
+                return "xmark.octagon"
+            }
+        }
+
+        var tintColor: Color {
+            switch self {
+            case .low:
+                return .green
+            case .medium:
+                return .orange
+            case .high:
+                return .red
+            }
+        }
+    }
+
+    let jointType: JointType
+    let riskLevel: RiskLevel
+    let summary: String
+    let recommendations: [String]
+}

--- a/ErgonomieApp/Resources/isoThresholds.json
+++ b/ErgonomieApp/Resources/isoThresholds.json
@@ -1,0 +1,11 @@
+{
+  "leftShoulder": { "warning": 60, "critical": 80, "maxDuration": 2 },
+  "rightShoulder": { "warning": 60, "critical": 80, "maxDuration": 2 },
+  "leftElbow": { "warning": 120, "critical": 140, "maxDuration": 4 },
+  "rightElbow": { "warning": 120, "critical": 140, "maxDuration": 4 },
+  "torso": { "warning": 20, "critical": 45, "maxDuration": 4 },
+  "leftHip": { "warning": 60, "critical": 80, "maxDuration": 3 },
+  "rightHip": { "warning": 60, "critical": 80, "maxDuration": 3 },
+  "leftKnee": { "warning": 90, "critical": 120, "maxDuration": 4 },
+  "rightKnee": { "warning": 90, "critical": 120, "maxDuration": 4 }
+}

--- a/ErgonomieApp/Services/AnalysisService.swift
+++ b/ErgonomieApp/Services/AnalysisService.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+actor AnalysisService {
+    private var rollingAngles: [JointType: [Double]] = [:]
+    private let isoThresholds = IsoThresholds()
+
+    func processLivePose(_ pose: PoseFrame) {
+        for (joint, angle) in pose.jointAngles {
+            var history = rollingAngles[joint, default: []]
+            history.append(angle)
+            if history.count > 120 {
+                history.removeFirst()
+            }
+            rollingAngles[joint] = history
+        }
+    }
+
+    func finalizeSession(with builder: PoseSessionBuilder) async -> PoseSession {
+        let aggregated = rollingAngles.mapValues { values -> Double in
+            guard !values.isEmpty else { return 0 }
+            return values.reduce(0, +) / Double(values.count)
+        }
+
+        let assessments = aggregated.map { joint, value in
+            isoThresholds.assessment(for: joint, angle: value)
+        }
+
+        let metrics = rollingAngles.flatMap { joint, values -> [PoseMetric] in
+            values.enumerated().map { index, value in
+                PoseMetric(joint: joint, timestamp: Date().addingTimeInterval(Double(index) / 30), value: value)
+            }
+        }
+
+        let session = builder.build(with: assessments, metrics: metrics)
+        rollingAngles.removeAll()
+        return session
+    }
+}

--- a/ErgonomieApp/Services/CaptureService.swift
+++ b/ErgonomieApp/Services/CaptureService.swift
@@ -1,0 +1,89 @@
+import AVFoundation
+import Combine
+import Foundation
+
+final class CaptureService: NSObject, ObservableObject {
+    @Published private(set) var isSessionRunning = false
+
+    private(set) lazy var session = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "capture.session.queue")
+    private let sampleBufferSubject = PassthroughSubject<CMSampleBuffer, Never>()
+
+    var isConfigured = false
+
+    var sampleBufferPublisher: AnyPublisher<CMSampleBuffer, Never> {
+        sampleBufferSubject.eraseToAnyPublisher()
+    }
+
+    func requestAuthorizationIfNeeded() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            break
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                if !granted {
+                    print("Accès caméra refusé")
+                }
+            }
+        default:
+            print("Autorisations caméra insuffisantes")
+        }
+    }
+
+    func configureSession() {
+        guard !isConfigured else { return }
+        session.beginConfiguration()
+        session.sessionPreset = .high
+
+        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) else {
+            print("Caméra arrière indisponible")
+            session.commitConfiguration()
+            return
+        }
+
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            if session.canAddInput(input) {
+                session.addInput(input)
+            }
+
+            let output = AVCaptureVideoDataOutput()
+            output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+            output.setSampleBufferDelegate(self, queue: sessionQueue)
+            if session.canAddOutput(output) {
+                session.addOutput(output)
+            }
+        } catch {
+            print("Erreur configuration session : \(error)")
+        }
+
+        session.commitConfiguration()
+        isConfigured = true
+    }
+
+    func startRunning() {
+        guard isConfigured else { return }
+        sessionQueue.async { [weak self] in
+            self?.session.startRunning()
+            DispatchQueue.main.async {
+                self?.isSessionRunning = true
+            }
+        }
+    }
+
+    func stopRunning() {
+        guard isConfigured else { return }
+        sessionQueue.async { [weak self] in
+            self?.session.stopRunning()
+            DispatchQueue.main.async {
+                self?.isSessionRunning = false
+            }
+        }
+    }
+}
+
+extension CaptureService: AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        sampleBufferSubject.send(sampleBuffer)
+    }
+}

--- a/ErgonomieApp/Services/DataStore.swift
+++ b/ErgonomieApp/Services/DataStore.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+actor DataStore {
+    static let shared = DataStore()
+
+    private let fileManager = FileManager.default
+    private let storeURL: URL
+
+    private init() {
+        let directory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? fileManager.temporaryDirectory
+        storeURL = directory.appendingPathComponent("sessions.json")
+    }
+
+    func save(session: PoseSession) async throws {
+        var sessions = try await fetchSessions()
+        sessions.append(session)
+        try persist(sessions: sessions)
+    }
+
+    func fetchSessions() async throws -> [PoseSession] {
+        guard fileManager.fileExists(atPath: storeURL.path) else {
+            return []
+        }
+        let data = try Data(contentsOf: storeURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([PoseSession].self, from: data)
+    }
+
+    private func persist(sessions: [PoseSession]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(sessions)
+        try data.write(to: storeURL, options: .atomic)
+    }
+}

--- a/ErgonomieApp/Services/PoseEstimator.swift
+++ b/ErgonomieApp/Services/PoseEstimator.swift
@@ -1,0 +1,102 @@
+import Combine
+import CoreGraphics
+import Foundation
+import Vision
+
+final class PoseEstimator {
+    private let request = VNDetectHumanBodyPoseRequest()
+
+    func estimatePose(from pixelBuffer: CVPixelBuffer) -> AnyPublisher<PoseFrame, Never> {
+        Future { promise in
+            let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: [:])
+            do {
+                try handler.perform([self.request])
+                let frame = try self.makePoseFrame()
+                promise(.success(frame))
+            } catch {
+                print("Erreur estimation pose : \(error)")
+                promise(.success(self.emptyPoseFrame()))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+
+    private func makePoseFrame() throws -> PoseFrame {
+        guard let observation = request.results?.first as? VNHumanBodyPoseObservation else {
+            throw PoseEstimatorError.noObservation
+        }
+
+        let recognizedPoints = try observation.recognizedPoints(.all)
+        var jointPositions: [JointType: NormalizedPoint] = [:]
+        for joint in JointType.allCases {
+            if let point = recognizedPoints[joint.visionJointName], point.confidence > 0.2 {
+                jointPositions[joint] = NormalizedPoint(x: CGFloat(point.x), y: CGFloat(point.y))
+            }
+        }
+
+        let jointAngles = PoseMath.computeAngles(for: jointPositions)
+        let criticalJoint = PoseMath.criticalJoint(for: jointAngles)
+        let isoScore = PoseMath.computeISOScore(from: jointAngles)
+
+        return PoseFrame(
+            timestamp: Date(),
+            jointPositions: jointPositions,
+            jointAngles: jointAngles,
+            repetitionEstimate: PoseMath.repetitionIndex(from: jointAngles),
+            mostCriticalJoint: criticalJoint,
+            isoScore: isoScore
+        )
+    }
+
+    private func emptyPoseFrame() -> PoseFrame {
+        PoseFrame(
+            timestamp: Date(),
+            jointPositions: [:],
+            jointAngles: [:],
+            repetitionEstimate: 0,
+            mostCriticalJoint: nil,
+            isoScore: 0
+        )
+    }
+}
+
+private extension JointType {
+    var visionJointName: VNHumanBodyPoseObservation.JointName {
+        switch self {
+        case .head:
+            return .head
+        case .neck:
+            return .neck
+        case .leftShoulder:
+            return .leftShoulder
+        case .rightShoulder:
+            return .rightShoulder
+        case .leftElbow:
+            return .leftElbow
+        case .rightElbow:
+            return .rightElbow
+        case .leftWrist:
+            return .leftWrist
+        case .rightWrist:
+            return .rightWrist
+        case .torso:
+            return .root
+        case .leftHip:
+            return .leftHip
+        case .rightHip:
+            return .rightHip
+        case .leftKnee:
+            return .leftKnee
+        case .rightKnee:
+            return .rightKnee
+        case .leftAnkle:
+            return .leftAnkle
+        case .rightAnkle:
+            return .rightAnkle
+        }
+    }
+}
+
+enum PoseEstimatorError: Error {
+    case noObservation
+}

--- a/ErgonomieApp/Services/PoseSessionBuilder.swift
+++ b/ErgonomieApp/Services/PoseSessionBuilder.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+final class PoseSessionBuilder {
+    private var frames: [PoseFrame] = []
+    private var metadata = SessionMetadata(date: Date(), taskName: "", operatorName: "", notes: "")
+
+    func updateMetadata(task: String, operatorName: String, notes: String) {
+        metadata = SessionMetadata(date: Date(), taskName: task, operatorName: operatorName, notes: notes)
+    }
+
+    func addPoseFrame(_ frame: PoseFrame) {
+        frames.append(frame)
+    }
+
+    func build(with assessments: [JointAssessment], metrics: [PoseMetric]) -> PoseSession {
+        PoseSession(id: UUID(), metadata: metadata, frames: frames, assessments: assessments, metrics: metrics)
+    }
+}

--- a/ErgonomieApp/Services/ReportService.swift
+++ b/ErgonomieApp/Services/ReportService.swift
@@ -1,0 +1,36 @@
+import Foundation
+import PDFKit
+import UIKit
+
+struct ReportService {
+    func exportPDF(for session: PoseSession) throws -> URL {
+        let pageBounds = CGRect(x: 0, y: 0, width: 595, height: 842)
+        let renderer = UIGraphicsPDFRenderer(bounds: pageBounds)
+        let data = renderer.pdfData { context in
+            context.beginPage()
+            let title = "Rapport ergonomique – \(session.metadata.taskName)"
+            title.draw(at: CGPoint(x: 32, y: 32), withAttributes: [.font: UIFont.boldSystemFont(ofSize: 22)])
+            var yOffset: CGFloat = 80
+            for assessment in session.assessments {
+                let text = "• \(assessment.jointType.rawValue): \(assessment.riskLevel.description)"
+                text.draw(at: CGPoint(x: 40, y: yOffset), withAttributes: [.font: UIFont.systemFont(ofSize: 14)])
+                yOffset += 24
+            }
+        }
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("Rapport-\(session.id).pdf")
+        try data.write(to: url)
+        return url
+    }
+
+    func exportCSV(for sessions: [PoseSession]) throws -> URL {
+        var csv = "session_id,task_name,joint,timestamp,angle\n"
+        for session in sessions {
+            for metric in session.metrics {
+                csv.append("\(session.id.uuidString),\(session.metadata.taskName),\(metric.joint.rawValue),\(metric.timestamp.timeIntervalSince1970),\(metric.value)\n")
+            }
+        }
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("Sessions.csv")
+        try csv.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/ErgonomieApp/Utilities/IsoThresholds.swift
+++ b/ErgonomieApp/Utilities/IsoThresholds.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct IsoThresholds: Codable {
+    struct Threshold: Codable {
+        let warning: Double
+        let critical: Double
+        let maxDuration: TimeInterval
+    }
+
+    private let thresholds: [JointType: Threshold]
+
+    init() {
+        if let url = Bundle.main.url(forResource: "isoThresholds", withExtension: "json"),
+           let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode([String: Threshold].self, from: data) {
+            var mapped: [JointType: Threshold] = [:]
+            for (key, value) in decoded {
+                if let joint = JointType(rawValue: key) {
+                    mapped[joint] = value
+                }
+            }
+            thresholds = mapped
+        } else {
+            thresholds = [:]
+        }
+    }
+
+    func assessment(for joint: JointType, angle: Double) -> JointAssessment {
+        let threshold = thresholds[joint] ?? Threshold(warning: 45, critical: 75, maxDuration: 4)
+        let riskLevel: JointAssessment.RiskLevel
+        if angle >= threshold.critical {
+            riskLevel = .high
+        } else if angle >= threshold.warning {
+            riskLevel = .medium
+        } else {
+            riskLevel = .low
+        }
+
+        let summary = "Angle moyen : \(Int(angle))° (seuil alerte : \(Int(threshold.warning))°)"
+        let recommendations: [String]
+        switch riskLevel {
+        case .low:
+            recommendations = ["Maintenir la posture dans les limites actuelles"]
+        case .medium:
+            recommendations = ["Planifier des pauses", "Ajuster le poste"]
+        case .high:
+            recommendations = ["Action immédiate", "Revoir l'organisation du travail"]
+        }
+
+        return JointAssessment(jointType: joint, riskLevel: riskLevel, summary: summary, recommendations: recommendations)
+    }
+}

--- a/ErgonomieApp/Utilities/PoseMath.swift
+++ b/ErgonomieApp/Utilities/PoseMath.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+import Foundation
+
+enum PoseMath {
+    static func computeAngles(for joints: [JointType: NormalizedPoint]) -> [JointType: Double] {
+        var angles: [JointType: Double] = [:]
+
+        func angle(between joint: JointType, _ first: JointType, _ second: JointType) -> Double? {
+            guard let center = joints[joint],
+                  let pointA = joints[first],
+                  let pointB = joints[second] else {
+                return nil
+            }
+            let vectorA = CGVector(dx: pointA.x - center.x, dy: pointA.y - center.y)
+            let vectorB = CGVector(dx: pointB.x - center.x, dy: pointB.y - center.y)
+            let dotProduct = vectorA.dx * vectorB.dx + vectorA.dy * vectorB.dy
+            let magnitudeA = sqrt(vectorA.dx * vectorA.dx + vectorA.dy * vectorA.dy)
+            let magnitudeB = sqrt(vectorB.dx * vectorB.dx + vectorB.dy * vectorB.dy)
+            guard magnitudeA > 0, magnitudeB > 0 else { return nil }
+            let cosine = max(-1, min(1, dotProduct / (magnitudeA * magnitudeB)))
+            let radians = acos(cosine)
+            return radians * 180 / .pi
+        }
+
+        let definitions: [(JointType, JointType, JointType)] = [
+            (.leftElbow, .leftShoulder, .leftWrist),
+            (.rightElbow, .rightShoulder, .rightWrist),
+            (.leftShoulder, .torso, .leftElbow),
+            (.rightShoulder, .torso, .rightElbow),
+            (.torso, .leftHip, .rightHip),
+            (.leftKnee, .leftHip, .leftAnkle),
+            (.rightKnee, .rightHip, .rightAnkle),
+            (.leftHip, .torso, .leftKnee),
+            (.rightHip, .torso, .rightKnee)
+        ]
+
+        for definition in definitions {
+            if let value = angle(between: definition.0, definition.1, definition.2) {
+                angles[definition.0] = value
+            }
+        }
+        return angles
+    }
+
+    static func criticalJoint(for angles: [JointType: Double]) -> JointType? {
+        angles.max(by: { lhs, rhs in
+            isoWeight(for: lhs.key) * lhs.value < isoWeight(for: rhs.key) * rhs.value
+        })?.key
+    }
+
+    static func repetitionIndex(from angles: [JointType: Double]) -> Double {
+        let average = angles.values.reduce(0, +) / Double(max(angles.count, 1))
+        return min(60, max(0, average / 3))
+    }
+
+    static func computeISOScore(from angles: [JointType: Double]) -> Int {
+        let total = angles.reduce(0.0) { partial, element in
+            partial + element.value * isoWeight(for: element.key)
+        }
+        return Int(total / Double(max(angles.count, 1)))
+    }
+
+    private static func isoWeight(for joint: JointType) -> Double {
+        switch joint {
+        case .leftShoulder, .rightShoulder:
+            return 1.5
+        case .leftElbow, .rightElbow:
+            return 1.2
+        case .torso:
+            return 2.0
+        case .leftHip, .rightHip:
+            return 1.3
+        default:
+            return 1.0
+        }
+    }
+}

--- a/ErgonomieApp/ViewModels/CaptureViewModel.swift
+++ b/ErgonomieApp/ViewModels/CaptureViewModel.swift
@@ -1,0 +1,86 @@
+import AVFoundation
+import Combine
+import Foundation
+import Vision
+
+@MainActor
+final class CaptureViewModel: ObservableObject {
+    @Published private(set) var latestPose: PoseFrame?
+    @Published private(set) var isRecording = false
+    @Published private(set) var statusMessage: String?
+
+    let captureService = CaptureService()
+    private let poseEstimator = PoseEstimator()
+    private let analysisService = AnalysisService()
+    private let dataStore = DataStore.shared
+
+    private var cancellables = Set<AnyCancellable>()
+    private var currentSessionBuilder = PoseSessionBuilder()
+
+    func configureIfNeeded() {
+        guard !captureService.isConfigured else { return }
+
+        captureService.requestAuthorizationIfNeeded()
+        captureService.configureSession()
+
+        captureService.sampleBufferPublisher
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
+            .compactMap { CMSampleBufferGetImageBuffer($0) }
+            .flatMap { [poseEstimator] pixelBuffer in
+                poseEstimator.estimatePose(from: pixelBuffer)
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] pose in
+                self?.handlePoseFrame(pose)
+            }
+            .store(in: &cancellables)
+
+        captureService.$isSessionRunning
+            .receive(on: DispatchQueue.main)
+            .map { $0 ? nil : "Caméra arrêtée" }
+            .assign(to: &$statusMessage)
+
+        captureService.startRunning()
+    }
+
+    func toggleRecording() {
+        isRecording.toggle()
+        if isRecording {
+            statusMessage = "Enregistrement en cours"
+            currentSessionBuilder = PoseSessionBuilder()
+        } else {
+            statusMessage = "Analyse en cours"
+            Task {
+                await finalizeSession()
+            }
+        }
+    }
+
+    func stop() {
+        captureService.stopRunning()
+        isRecording = false
+    }
+
+    private func handlePoseFrame(_ pose: PoseFrame) {
+        latestPose = pose
+        guard isRecording else { return }
+        currentSessionBuilder.addPoseFrame(pose)
+        Task {
+            await analysisService.processLivePose(pose)
+        }
+    }
+
+    private func finalizeSession() async {
+        let session = await analysisService.finalizeSession(with: currentSessionBuilder)
+        do {
+            try await dataStore.save(session: session)
+            await MainActor.run {
+                statusMessage = "Session enregistrée"
+            }
+        } catch {
+            await MainActor.run {
+                statusMessage = "Erreur sauvegarde : \(error.localizedDescription)"
+            }
+        }
+    }
+}

--- a/ErgonomieApp/ViewModels/DashboardViewModel.swift
+++ b/ErgonomieApp/ViewModels/DashboardViewModel.swift
@@ -1,0 +1,84 @@
+import Combine
+import Foundation
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published private(set) var sessions: [PoseSession] = []
+    @Published private(set) var liveMetrics: LiveMetrics?
+
+    private let dataStore = DataStore.shared
+    private var captureViewModel: CaptureViewModel?
+
+    func bind(to captureViewModel: CaptureViewModel) {
+        guard self.captureViewModel !== captureViewModel else { return }
+        self.captureViewModel = captureViewModel
+        captureViewModel.$latestPose
+            .compactMap { $0 }
+            .map { pose in
+                LiveMetrics(pose: pose)
+            }
+            .assign(to: &$liveMetrics)
+    }
+
+    func loadSessions() async {
+        do {
+            sessions = try await dataStore.fetchSessions()
+        } catch {
+            print("Erreur chargement sessions : \(error)")
+        }
+    }
+
+    func exportLatestReport() async -> ExportResult {
+        guard let session = sessions.sorted(by: { $0.metadata.date > $1.metadata.date }).first else {
+            return ExportResult.failure("Aucune session disponible")
+        }
+        do {
+            let url = try ReportService().exportPDF(for: session)
+            return ExportResult.success("PDF exporté : \(url.lastPathComponent)")
+        } catch {
+            return ExportResult.failure("Échec export PDF : \(error.localizedDescription)")
+        }
+    }
+
+    func exportCSV() async -> ExportResult {
+        do {
+            let url = try ReportService().exportCSV(for: sessions)
+            return ExportResult.success("CSV exporté : \(url.lastPathComponent)")
+        } catch {
+            return ExportResult.failure("Échec export CSV : \(error.localizedDescription)")
+        }
+    }
+}
+
+struct LiveMetrics {
+    private let pose: PoseFrame
+
+    init(pose: PoseFrame) {
+        self.pose = pose
+    }
+
+    var repetitionFrequency: String {
+        "\(pose.repetitionEstimate, specifier: "%.1f") cycles/min"
+    }
+
+    var criticalPostureDescription: String {
+        pose.mostCriticalJoint?.rawValue ?? "Stable"
+    }
+
+    var isoScoreDescription: String {
+        "Score ISO : \(pose.isoScore)"
+    }
+}
+
+struct ExportResult {
+    let isSuccess: Bool
+    let message: String
+
+    static func success(_ message: String) -> ExportResult {
+        ExportResult(isSuccess: true, message: message)
+    }
+
+    static func failure(_ message: String) -> ExportResult {
+        ExportResult(isSuccess: false, message: message)
+    }
+}

--- a/ErgonomieApp/Views/CameraPreviewView.swift
+++ b/ErgonomieApp/Views/CameraPreviewView.swift
@@ -1,0 +1,30 @@
+import AVFoundation
+import SwiftUI
+
+struct CameraPreviewView: UIViewRepresentable {
+    final class PreviewView: UIView {
+        override class var layerClass: AnyClass {
+            AVCaptureVideoPreviewLayer.self
+        }
+
+        var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+            guard let layer = layer as? AVCaptureVideoPreviewLayer else {
+                fatalError("Layer must be AVCaptureVideoPreviewLayer")
+            }
+            return layer
+        }
+    }
+
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.videoPreviewLayer.session = session
+        view.videoPreviewLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {
+        uiView.videoPreviewLayer.session = session
+    }
+}

--- a/ErgonomieApp/Views/CaptureScreen.swift
+++ b/ErgonomieApp/Views/CaptureScreen.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct CaptureScreen: View {
+    @EnvironmentObject private var captureViewModel: CaptureViewModel
+    @EnvironmentObject private var dashboardViewModel: DashboardViewModel
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            CameraPreviewView(session: captureViewModel.captureService.session)
+                .ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                PoseOverlayView(pose: captureViewModel.latestPose)
+                    .frame(height: 200)
+                    .padding(.horizontal)
+
+                CaptureControls()
+            }
+            .padding()
+            .background(.regularMaterial)
+        }
+        .onAppear {
+            captureViewModel.configureIfNeeded()
+            dashboardViewModel.bind(to: captureViewModel)
+        }
+        .onDisappear {
+            captureViewModel.stop()
+        }
+    }
+}
+
+private struct CaptureControls: View {
+    @EnvironmentObject private var captureViewModel: CaptureViewModel
+
+    var body: some View {
+        HStack(spacing: 24) {
+            Button(action: captureViewModel.toggleRecording) {
+                Label(captureViewModel.isRecording ? "Arrêter" : "Enregistrer",
+                      systemImage: captureViewModel.isRecording ? "stop.circle" : "record.circle")
+                    .font(.title3.bold())
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 20)
+                    .background(Color.accentColor.opacity(0.2))
+                    .clipShape(Capsule())
+            }
+
+            if let message = captureViewModel.statusMessage {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}

--- a/ErgonomieApp/Views/DashboardView.swift
+++ b/ErgonomieApp/Views/DashboardView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject private var dashboardViewModel: DashboardViewModel
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Session en cours") {
+                    if let metrics = dashboardViewModel.liveMetrics {
+                        MetricRow(title: "Fréquence répétitions", value: metrics.repetitionFrequency)
+                        MetricRow(title: "Posture critique", value: metrics.criticalPostureDescription)
+                        MetricRow(title: "Score ISO", value: metrics.isoScoreDescription)
+                    } else {
+                        Text("Aucune donnée en direct")
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Section("Historique") {
+                    ForEach(dashboardViewModel.sessions) { session in
+                        NavigationLink(destination: SessionDetailView(session: session)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(session.metadata.taskName)
+                                    .font(.headline)
+                                Text(session.metadata.formattedDate)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Tableau de bord")
+            .task {
+                await dashboardViewModel.loadSessions()
+            }
+        }
+    }
+}
+
+private struct MetricRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .bold()
+        }
+    }
+}

--- a/ErgonomieApp/Views/PoseOverlayView.swift
+++ b/ErgonomieApp/Views/PoseOverlayView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct PoseOverlayView: View {
+    let pose: PoseFrame?
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                if let pose {
+                    ForEach(pose.jointPositions.keys.sorted(), id: \.self) { joint in
+                        if let normalized = pose.jointPositions[joint] {
+                            let position = CGPoint(x: normalized.x * geometry.size.width,
+                                                   y: (1 - normalized.y) * geometry.size.height)
+                            JointView(name: joint.rawValue, position: position)
+                        }
+                    }
+
+                    ForEach(pose.jointConnections, id: \.self) { connection in
+                        if let start = pose.jointPositions[connection.0],
+                           let end = pose.jointPositions[connection.1] {
+                            let startPoint = CGPoint(x: start.x * geometry.size.width,
+                                                     y: (1 - start.y) * geometry.size.height)
+                            let endPoint = CGPoint(x: end.x * geometry.size.width,
+                                                   y: (1 - end.y) * geometry.size.height)
+                            Path { path in
+                                path.move(to: startPoint)
+                                path.addLine(to: endPoint)
+                            }
+                            .stroke(Color.orange, lineWidth: 2)
+                        }
+                    }
+                } else {
+                    Text("Aucune pose détectée")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .animation(.easeInOut, value: pose?.id)
+        }
+    }
+}
+
+private struct JointView: View {
+    let name: String
+    let position: CGPoint
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Circle()
+                .fill(Color.accentColor)
+                .frame(width: 10, height: 10)
+            Text(name)
+                .font(.caption2)
+                .foregroundColor(.white)
+                .padding(4)
+                .background(Color.black.opacity(0.6))
+                .clipShape(Capsule())
+        }
+        .position(position)
+    }
+}

--- a/ErgonomieApp/Views/ReportsView.swift
+++ b/ErgonomieApp/Views/ReportsView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ReportsView: View {
+    @EnvironmentObject private var dashboardViewModel: DashboardViewModel
+    @State private var exportResult: ExportResult?
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Exporter") {
+                    Button("Exporter le dernier rapport PDF") {
+                        Task {
+                            exportResult = await dashboardViewModel.exportLatestReport()
+                        }
+                    }
+                    Button("Exporter les données CSV") {
+                        Task {
+                            exportResult = await dashboardViewModel.exportCSV()
+                        }
+                    }
+                }
+
+                if let exportResult {
+                    Section("Dernière exportation") {
+                        Text(exportResult.message)
+                            .foregroundColor(exportResult.isSuccess ? .green : .red)
+                    }
+                }
+            }
+            .navigationTitle("Rapports")
+        }
+    }
+}

--- a/ErgonomieApp/Views/SessionDetailView.swift
+++ b/ErgonomieApp/Views/SessionDetailView.swift
@@ -1,0 +1,65 @@
+import Charts
+import SwiftUI
+
+struct SessionDetailView: View {
+    let session: PoseSession
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                SectionHeader("Résumé ISO")
+                ForEach(session.assessments.sorted(by: { $0.jointType.rawValue < $1.jointType.rawValue }), id: \.jointType) { assessment in
+                    AssessmentCard(assessment: assessment)
+                }
+
+                SectionHeader("Angles clés")
+                Chart(session.metrics) { metric in
+                    LineMark(
+                        x: .value("Temps", metric.timestamp),
+                        y: .value("Angle", metric.value)
+                    )
+                    .foregroundStyle(by: .value("Articulation", metric.joint.rawValue))
+                }
+                .frame(height: 240)
+            }
+            .padding()
+        }
+        .navigationTitle(session.metadata.taskName)
+    }
+}
+
+private struct SectionHeader: View {
+    let title: String
+
+    init(_ title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        Text(title)
+            .font(.title2.bold())
+    }
+}
+
+private struct AssessmentCard: View {
+    let assessment: JointAssessment
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(assessment.jointType.rawValue)
+                    .font(.headline)
+                Spacer()
+                Label(assessment.riskLevel.description, systemImage: assessment.riskLevel.iconName)
+                    .foregroundColor(assessment.riskLevel.tintColor)
+            }
+            Text(assessment.summary)
+                .font(.body)
+            Text("Recommandations : \(assessment.recommendations.joined(separator: ", "))")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Ergonomie – Application d'expertise ergonomique sur iOS
 
-Ce dépôt décrit la conception d'une application iOS destinée aux ergonomes
-pour analyser les mouvements filmés sur le terrain à l'aide d'un iPhone 13.
-L'objectif est de fournir un outil mobile capable de :
+Ce dépôt fournit désormais un squelette complet en SwiftUI prêt à être ouvert
+dans Xcode pour compiler sur iPhone 13. L'application permet de :
 
 * filmer un travailleur et suivre ses articulations en temps réel ;
 * calculer les angles articulaires, la durée des postures/mouvements et les
@@ -24,3 +23,20 @@ la documentation du dossier `docs/`.
 
 Ces documents servent de guide pour démarrer le développement natif Swift et
 coordonner l'équipe produit, recherche ergonomique et développement logiciel.
+
+## Démarrage rapide dans Xcode
+
+1. Ouvrir Xcode 15+ et créer un nouveau projet "App" en SwiftUI nommé
+   `ErgonomieApp` avec iOS 16 comme cible minimale.
+2. Copier le contenu du dossier `ErgonomieApp/` de ce dépôt dans le dossier
+   source du projet Xcode généré (remplacer les fichiers `ContentView.swift`
+   et `NomDuProjetApp.swift`).
+3. Ajouter `isoThresholds.json` au groupe "Resources" en vous assurant que le
+   fichier est inclus dans la cible iOS.
+4. Activer les capacités caméra dans `Info.plist` en ajoutant les clefs
+   `NSCameraUsageDescription` et `NSPhotoLibraryAddUsageDescription` avec un
+   texte expliquant l'usage ergonomique.
+5. Lancer sur un iPhone 13 (ou simulateur caméra si disponible). L'écran
+   "Capture" affiche l'aperçu vidéo et superpose la détection de pose, puis les
+   onglets "Tableau de bord" et "Rapports" donnent accès aux métriques ISO et à
+   l'export PDF/CSV.


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS application skeleton with capture, dashboard, and reporting tabs wired to Vision-based pose estimation and ergonomic analysis services
- implement services for camera capture, pose estimation, ISO threshold evaluation, data persistence, and PDF/CSV exports with reusable utilities and resources
- document Xcode integration steps to run the project on iPhone 13

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccb38c4b948322b5d0fc48c0586b1e