### PR TITLE
Add live camera analysis workflow and reporting

### DIFF
--- a/ErgonomieApp/Models/JointType.swift
+++ b/ErgonomieApp/Models/JointType.swift
@@ -20,4 +20,39 @@ enum JointType: String, CaseIterable, Codable, Comparable {
     static func < (lhs: JointType, rhs: JointType) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
+
+    var localizedName: String {
+        switch self {
+        case .head:
+            return "Tête"
+        case .neck:
+            return "Cou"
+        case .leftShoulder:
+            return "Épaule gauche"
+        case .rightShoulder:
+            return "Épaule droite"
+        case .leftElbow:
+            return "Coude gauche"
+        case .rightElbow:
+            return "Coude droit"
+        case .leftWrist:
+            return "Poignet gauche"
+        case .rightWrist:
+            return "Poignet droit"
+        case .torso:
+            return "Torse"
+        case .leftHip:
+            return "Hanche gauche"
+        case .rightHip:
+            return "Hanche droite"
+        case .leftKnee:
+            return "Genou gauche"
+        case .rightKnee:
+            return "Genou droit"
+        case .leftAnkle:
+            return "Cheville gauche"
+        case .rightAnkle:
+            return "Cheville droite"
+        }
+    }
 }

--- a/ErgonomieApp/Models/PoseSession.swift
+++ b/ErgonomieApp/Models/PoseSession.swift
@@ -7,6 +7,49 @@ struct PoseSession: Identifiable, Codable {
     let frames: [PoseFrame]
     let assessments: [JointAssessment]
     let metrics: [PoseMetric]
+    let summary: SessionSummary
+
+    init(id: UUID, metadata: SessionMetadata, frames: [PoseFrame], assessments: [JointAssessment], metrics: [PoseMetric], summary: SessionSummary) {
+        self.id = id
+        self.metadata = metadata
+        self.frames = frames
+        self.assessments = assessments
+        self.metrics = metrics
+        self.summary = summary
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case metadata
+        case frames
+        case assessments
+        case metrics
+        case summary
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        metadata = try container.decode(SessionMetadata.self, forKey: .metadata)
+        frames = try container.decode([PoseFrame].self, forKey: .frames)
+        assessments = try container.decode([JointAssessment].self, forKey: .assessments)
+        metrics = try container.decode([PoseMetric].self, forKey: .metrics)
+        if let decodedSummary = try container.decodeIfPresent(SessionSummary.self, forKey: .summary) {
+            summary = decodedSummary
+        } else {
+            summary = SessionSummary.fallback(from: frames)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(metadata, forKey: .metadata)
+        try container.encode(frames, forKey: .frames)
+        try container.encode(assessments, forKey: .assessments)
+        try container.encode(metrics, forKey: .metrics)
+        try container.encode(summary, forKey: .summary)
+    }
 }
 
 struct SessionMetadata: Codable {
@@ -28,6 +71,145 @@ struct PoseMetric: Identifiable, Codable {
     let joint: JointType
     let timestamp: Date
     let value: Double
+}
+
+struct SessionSummary: Codable {
+    struct JointSummary: Identifiable, Codable {
+        enum IsoStatus: String, Codable {
+            case compliant
+            case attention
+            case critical
+            case unknown
+
+            var description: String {
+                switch self {
+                case .compliant:
+                    return "Conforme aux normes"
+                case .attention:
+                    return "Surveillance requise"
+                case .critical:
+                    return "Dépassement critique"
+                case .unknown:
+                    return "Normes indisponibles"
+                }
+            }
+
+            var tintColor: Color {
+                switch self {
+                case .compliant:
+                    return .green
+                case .attention:
+                    return .orange
+                case .critical:
+                    return .red
+                case .unknown:
+                    return .gray
+                }
+            }
+        }
+
+        let joint: JointType
+        let movementCount: Int
+        let averageAngle: Double
+        let minAngle: Double
+        let maxAngle: Double
+        let isoWarning: Double?
+        let isoCritical: Double?
+        let isoStatus: IsoStatus
+
+        var id: JointType { joint }
+
+        var averageDescription: String {
+            "\(averageAngle, specifier: "%.1f")°"
+        }
+
+        var rangeDescription: String {
+            "Min \(minAngle, specifier: "%.0f")° – Max \(maxAngle, specifier: "%.0f")°"
+        }
+
+        var isoDescription: String {
+            switch isoStatus {
+            case .unknown:
+                return isoStatus.description
+            case .compliant:
+                return isoStatus.description
+            case .attention, .critical:
+                if let warning = isoWarning, let critical = isoCritical {
+                    return "\(isoStatus.description) (alerte \(Int(warning))°, critique \(Int(critical))°)"
+                } else {
+                    return "\(isoStatus.description) (seuils indisponibles)"
+                }
+            }
+        }
+    }
+
+    let duration: TimeInterval
+    let frameCount: Int
+    let jointSummaries: [JointSummary]
+
+    var formattedDuration: String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .abbreviated
+        formatter.allowedUnits = duration >= 3600 ? [.hour, .minute, .second] : [.minute, .second]
+        return formatter.string(from: duration) ?? "0s"
+    }
+
+    var hasJointData: Bool {
+        !jointSummaries.isEmpty
+    }
+
+    static func fallback(from frames: [PoseFrame]) -> SessionSummary {
+        let duration: TimeInterval
+        if let first = frames.first?.timestamp, let last = frames.last?.timestamp {
+            duration = max(0, last.timeIntervalSince(first))
+        } else {
+            duration = 0
+        }
+
+        var accumulator: [JointType: (sum: Double, count: Int, min: Double, max: Double)] = [:]
+        for frame in frames {
+            for (joint, angle) in frame.jointAngles {
+                var entry = accumulator[joint] ?? (0, 0, .greatestFiniteMagnitude, -.greatestFiniteMagnitude)
+                entry.sum += angle
+                entry.count += 1
+                entry.min = Swift.min(entry.min, angle)
+                entry.max = Swift.max(entry.max, angle)
+                accumulator[joint] = entry
+            }
+        }
+
+        let thresholds = IsoThresholds()
+        let jointSummaries = accumulator.map { joint, value -> JointSummary in
+            let average = value.count > 0 ? value.sum / Double(value.count) : 0
+            let threshold = thresholds.threshold(for: joint)
+            let isoStatus: JointSummary.IsoStatus
+            if let threshold {
+                if average >= threshold.critical {
+                    isoStatus = .critical
+                } else if average >= threshold.warning {
+                    isoStatus = .attention
+                } else {
+                    isoStatus = .compliant
+                }
+            } else {
+                isoStatus = .unknown
+            }
+
+            return JointSummary(
+                joint: joint,
+                movementCount: 0,
+                averageAngle: average,
+                minAngle: value.min.isFinite ? value.min : 0,
+                maxAngle: value.max.isFinite ? value.max : 0,
+                isoWarning: threshold?.warning,
+                isoCritical: threshold?.critical,
+                isoStatus: isoStatus
+            )
+        }
+        .sorted(by: { $0.joint < $1.joint })
+
+        return SessionSummary(duration: duration, frameCount: frames.count, jointSummaries: jointSummaries)
+    }
 }
 
 struct JointAssessment: Codable {

--- a/ErgonomieApp/Services/AnalysisService.swift
+++ b/ErgonomieApp/Services/AnalysisService.swift
@@ -1,38 +1,105 @@
 import Foundation
 
 actor AnalysisService {
-    private var rollingAngles: [JointType: [Double]] = [:]
+    private struct AngleAccumulator {
+        var min: Double = .greatestFiniteMagnitude
+        var max: Double = -.greatestFiniteMagnitude
+        var sum: Double = 0
+        var count: Int = 0
+
+        mutating func add(_ value: Double) {
+            min = Swift.min(min, value)
+            max = Swift.max(max, value)
+            sum += value
+            count += 1
+        }
+
+        var average: Double {
+            guard count > 0 else { return 0 }
+            return sum / Double(count)
+        }
+    }
+
     private let isoThresholds = IsoThresholds()
+    private var accumulators: [JointType: AngleAccumulator] = [:]
+    private var movementCounts: [JointType: Int] = [:]
+    private var lastAngles: [JointType: Double] = [:]
+
+    func startSession() {
+        accumulators.removeAll()
+        movementCounts.removeAll()
+        lastAngles.removeAll()
+    }
 
     func processLivePose(_ pose: PoseFrame) {
         for (joint, angle) in pose.jointAngles {
-            var history = rollingAngles[joint, default: []]
-            history.append(angle)
-            if history.count > 120 {
-                history.removeFirst()
+            var accumulator = accumulators[joint, default: AngleAccumulator()]
+            accumulator.add(angle)
+            accumulators[joint] = accumulator
+
+            if let last = lastAngles[joint], abs(angle - last) >= 7 {
+                movementCounts[joint, default: 0] += 1
             }
-            rollingAngles[joint] = history
+            lastAngles[joint] = angle
         }
     }
 
     func finalizeSession(with builder: PoseSessionBuilder) async -> PoseSession {
-        let aggregated = rollingAngles.mapValues { values -> Double in
-            guard !values.isEmpty else { return 0 }
-            return values.reduce(0, +) / Double(values.count)
-        }
-
-        let assessments = aggregated.map { joint, value in
-            isoThresholds.assessment(for: joint, angle: value)
-        }
-
-        let metrics = rollingAngles.flatMap { joint, values -> [PoseMetric] in
-            values.enumerated().map { index, value in
-                PoseMetric(joint: joint, timestamp: Date().addingTimeInterval(Double(index) / 30), value: value)
+        let frames = builder.recordedFrames
+        let metrics = frames.flatMap { frame -> [PoseMetric] in
+            frame.jointAngles.map { joint, value in
+                PoseMetric(joint: joint, timestamp: frame.timestamp, value: value)
             }
         }
 
-        let session = builder.build(with: assessments, metrics: metrics)
-        rollingAngles.removeAll()
+        let assessments = accumulators.map { joint, accumulator in
+            isoThresholds.assessment(for: joint, angle: accumulator.average)
+        }
+
+        let jointSummaries = accumulators.map { joint, accumulator -> SessionSummary.JointSummary in
+            let threshold = isoThresholds.threshold(for: joint)
+            let minAngle = accumulator.min.isFinite ? accumulator.min : 0
+            let maxAngle = accumulator.max.isFinite ? accumulator.max : 0
+            let average = accumulator.average
+            let isoStatus: SessionSummary.JointSummary.IsoStatus
+            if let threshold {
+                if average >= threshold.critical {
+                    isoStatus = .critical
+                } else if average >= threshold.warning {
+                    isoStatus = .attention
+                } else {
+                    isoStatus = .compliant
+                }
+            } else {
+                isoStatus = .unknown
+            }
+
+            return SessionSummary.JointSummary(
+                joint: joint,
+                movementCount: movementCounts[joint, default: 0],
+                averageAngle: average,
+                minAngle: minAngle,
+                maxAngle: maxAngle,
+                isoWarning: threshold?.warning,
+                isoCritical: threshold?.critical,
+                isoStatus: isoStatus
+            )
+        }
+        .sorted(by: { $0.joint < $1.joint })
+
+        let summary = SessionSummary(
+            duration: builder.sessionDuration,
+            frameCount: builder.frameCount,
+            jointSummaries: jointSummaries
+        )
+
+        let session = builder.build(
+            with: assessments.sorted(by: { $0.jointType < $1.jointType }),
+            metrics: metrics.sorted(by: { $0.timestamp < $1.timestamp }),
+            summary: summary
+        )
+
+        startSession()
         return session
     }
 }

--- a/ErgonomieApp/Services/CaptureService.swift
+++ b/ErgonomieApp/Services/CaptureService.swift
@@ -15,18 +15,26 @@ final class CaptureService: NSObject, ObservableObject {
         sampleBufferSubject.eraseToAnyPublisher()
     }
 
-    func requestAuthorizationIfNeeded() {
+    func requestAuthorizationIfNeeded(completion: @escaping (Bool) -> Void) {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
-            break
+            DispatchQueue.main.async {
+                completion(true)
+            }
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { granted in
                 if !granted {
                     print("Accès caméra refusé")
                 }
+                DispatchQueue.main.async {
+                    completion(granted)
+                }
             }
         default:
-            print("Autorisations caméra insuffisantes")
+            DispatchQueue.main.async {
+                print("Autorisations caméra insuffisantes")
+                completion(false)
+            }
         }
     }
 

--- a/ErgonomieApp/Services/PoseSessionBuilder.swift
+++ b/ErgonomieApp/Services/PoseSessionBuilder.swift
@@ -12,7 +12,27 @@ final class PoseSessionBuilder {
         frames.append(frame)
     }
 
-    func build(with assessments: [JointAssessment], metrics: [PoseMetric]) -> PoseSession {
-        PoseSession(id: UUID(), metadata: metadata, frames: frames, assessments: assessments, metrics: metrics)
+    var frameCount: Int {
+        frames.count
+    }
+
+    var sessionDuration: TimeInterval {
+        guard let first = frames.first?.timestamp, let last = frames.last?.timestamp else { return 0 }
+        return max(0, last.timeIntervalSince(first))
+    }
+
+    var recordedFrames: [PoseFrame] {
+        frames
+    }
+
+    func build(with assessments: [JointAssessment], metrics: [PoseMetric], summary: SessionSummary) -> PoseSession {
+        PoseSession(
+            id: UUID(),
+            metadata: metadata,
+            frames: frames,
+            assessments: assessments,
+            metrics: metrics,
+            summary: summary
+        )
     }
 }

--- a/ErgonomieApp/Utilities/IsoThresholds.swift
+++ b/ErgonomieApp/Utilities/IsoThresholds.swift
@@ -49,4 +49,8 @@ struct IsoThresholds: Codable {
 
         return JointAssessment(jointType: joint, riskLevel: riskLevel, summary: summary, recommendations: recommendations)
     }
+
+    func threshold(for joint: JointType) -> Threshold? {
+        thresholds[joint]
+    }
 }

--- a/ErgonomieApp/ViewModels/CaptureViewModel.swift
+++ b/ErgonomieApp/ViewModels/CaptureViewModel.swift
@@ -6,8 +6,10 @@ import Vision
 @MainActor
 final class CaptureViewModel: ObservableObject {
     @Published private(set) var latestPose: PoseFrame?
-    @Published private(set) var isRecording = false
+    @Published private(set) var isLiveAnalyzing = false
     @Published private(set) var statusMessage: String?
+    @Published private(set) var authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    @Published private(set) var lastSessionSummary: SessionSummary?
 
     let captureService = CaptureService()
     private let poseEstimator = PoseEstimator()
@@ -16,11 +18,86 @@ final class CaptureViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private var currentSessionBuilder = PoseSessionBuilder()
+    private var hasConfiguredPipeline = false
 
     func configureIfNeeded() {
-        guard !captureService.isConfigured else { return }
+        captureService.requestAuthorizationIfNeeded { [weak self] granted in
+            guard let self else { return }
+            Task { @MainActor in
+                self.authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+                guard granted else {
+                    self.statusMessage = "Autorisation caméra requise"
+                    return
+                }
+                self.setupSessionIfNeeded()
+            }
+        }
+    }
 
-        captureService.requestAuthorizationIfNeeded()
+    func startLiveAnalysis() {
+        guard authorizationStatus == .authorized else {
+            statusMessage = "Autorisation caméra requise"
+            return
+        }
+        guard !isLiveAnalyzing else { return }
+
+        lastSessionSummary = nil
+        currentSessionBuilder = PoseSessionBuilder()
+        isLiveAnalyzing = true
+        statusMessage = "Analyse en direct"
+
+        Task {
+            await analysisService.startSession()
+        }
+    }
+
+    func stopLiveAnalysis() {
+        guard isLiveAnalyzing else { return }
+
+        isLiveAnalyzing = false
+        statusMessage = "Analyse en cours"
+
+        Task {
+            await finalizeSession()
+        }
+    }
+
+    func stop() {
+        captureService.stopRunning()
+        isLiveAnalyzing = false
+    }
+
+    private func handlePoseFrame(_ pose: PoseFrame) {
+        latestPose = pose
+        guard isLiveAnalyzing else { return }
+        currentSessionBuilder.addPoseFrame(pose)
+        Task {
+            await analysisService.processLivePose(pose)
+        }
+    }
+
+    private func finalizeSession() async {
+        let session = await analysisService.finalizeSession(with: currentSessionBuilder)
+        do {
+            try await dataStore.save(session: session)
+            await MainActor.run {
+                lastSessionSummary = session.summary
+                statusMessage = "Rapport enregistré"
+            }
+        } catch {
+            await MainActor.run {
+                statusMessage = "Erreur sauvegarde : \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func setupSessionIfNeeded() {
+        guard !hasConfiguredPipeline else {
+            captureService.startRunning()
+            statusMessage = "Caméra prête"
+            return
+        }
+
         captureService.configureSession()
 
         captureService.sampleBufferPublisher
@@ -37,50 +114,20 @@ final class CaptureViewModel: ObservableObject {
 
         captureService.$isSessionRunning
             .receive(on: DispatchQueue.main)
-            .map { $0 ? nil : "Caméra arrêtée" }
-            .assign(to: &$statusMessage)
+            .sink { [weak self] running in
+                guard let self else { return }
+                if running {
+                    if !self.isLiveAnalyzing {
+                        self.statusMessage = "Caméra prête"
+                    }
+                } else {
+                    self.statusMessage = "Caméra arrêtée"
+                    self.isLiveAnalyzing = false
+                }
+            }
+            .store(in: &cancellables)
 
         captureService.startRunning()
-    }
-
-    func toggleRecording() {
-        isRecording.toggle()
-        if isRecording {
-            statusMessage = "Enregistrement en cours"
-            currentSessionBuilder = PoseSessionBuilder()
-        } else {
-            statusMessage = "Analyse en cours"
-            Task {
-                await finalizeSession()
-            }
-        }
-    }
-
-    func stop() {
-        captureService.stopRunning()
-        isRecording = false
-    }
-
-    private func handlePoseFrame(_ pose: PoseFrame) {
-        latestPose = pose
-        guard isRecording else { return }
-        currentSessionBuilder.addPoseFrame(pose)
-        Task {
-            await analysisService.processLivePose(pose)
-        }
-    }
-
-    private func finalizeSession() async {
-        let session = await analysisService.finalizeSession(with: currentSessionBuilder)
-        do {
-            try await dataStore.save(session: session)
-            await MainActor.run {
-                statusMessage = "Session enregistrée"
-            }
-        } catch {
-            await MainActor.run {
-                statusMessage = "Erreur sauvegarde : \(error.localizedDescription)"
-            }
-        }
+        hasConfiguredPipeline = true
     }
 }

--- a/ErgonomieApp/ViewModels/DashboardViewModel.swift
+++ b/ErgonomieApp/ViewModels/DashboardViewModel.swift
@@ -62,7 +62,7 @@ struct LiveMetrics {
     }
 
     var criticalPostureDescription: String {
-        pose.mostCriticalJoint?.rawValue ?? "Stable"
+        pose.mostCriticalJoint?.localizedName ?? "Stable"
     }
 
     var isoScoreDescription: String {

--- a/ErgonomieApp/Views/CaptureScreen.swift
+++ b/ErgonomieApp/Views/CaptureScreen.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 
 struct CaptureScreen: View {
@@ -5,19 +6,27 @@ struct CaptureScreen: View {
     @EnvironmentObject private var dashboardViewModel: DashboardViewModel
 
     var body: some View {
-        ZStack(alignment: .bottom) {
+        ZStack {
             CameraPreviewView(session: captureViewModel.captureService.session)
                 .ignoresSafeArea()
 
-            VStack(spacing: 16) {
-                PoseOverlayView(pose: captureViewModel.latestPose)
-                    .frame(height: 200)
-                    .padding(.horizontal)
+            PoseOverlayView(pose: captureViewModel.latestPose)
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
 
-                CaptureControls()
+            if captureViewModel.authorizationStatus != .authorized {
+                PermissionOverlay(status: captureViewModel.authorizationStatus)
             }
-            .padding()
-            .background(.regularMaterial)
+
+            VStack {
+                Spacer()
+
+                BottomPanel()
+                    .padding()
+                    .background(.ultraThinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                    .padding()
+            }
         }
         .onAppear {
             captureViewModel.configureIfNeeded()
@@ -33,22 +42,160 @@ private struct CaptureControls: View {
     @EnvironmentObject private var captureViewModel: CaptureViewModel
 
     var body: some View {
-        HStack(spacing: 24) {
-            Button(action: captureViewModel.toggleRecording) {
-                Label(captureViewModel.isRecording ? "Arrêter" : "Enregistrer",
-                      systemImage: captureViewModel.isRecording ? "stop.circle" : "record.circle")
-                    .font(.title3.bold())
+        HStack(spacing: 16) {
+            Button(action: captureViewModel.startLiveAnalysis) {
+                Label("Lancer l'analyse", systemImage: "play.circle.fill")
+                    .font(.headline)
                     .padding(.vertical, 12)
                     .padding(.horizontal, 20)
-                    .background(Color.accentColor.opacity(0.2))
+                    .background(captureViewModel.isLiveAnalyzing ? Color.accentColor.opacity(0.15) : Color.accentColor)
+                    .foregroundColor(captureViewModel.isLiveAnalyzing ? .accentColor : .white)
                     .clipShape(Capsule())
+            }
+            .disabled(captureViewModel.isLiveAnalyzing)
+
+            if captureViewModel.isLiveAnalyzing {
+                Button(role: .destructive, action: captureViewModel.stopLiveAnalysis) {
+                    Label("Terminer", systemImage: "stop.circle")
+                        .font(.headline)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 20)
+                        .background(Color.red.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+}
+
+private struct BottomPanel: View {
+    @EnvironmentObject private var captureViewModel: CaptureViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if captureViewModel.isLiveAnalyzing, let pose = captureViewModel.latestPose, !pose.jointAngles.isEmpty {
+                LiveAnglesPanel(pose: pose)
+            }
+
+            CaptureControls()
+
+            if let summary = captureViewModel.lastSessionSummary, !captureViewModel.isLiveAnalyzing {
+                SessionSummaryCard(summary: summary)
             }
 
             if let message = captureViewModel.statusMessage {
                 Text(message)
                     .font(.footnote)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct LiveAnglesPanel: View {
+    let pose: PoseFrame
+
+    private var sortedAngles: [(JointType, Double)] {
+        pose.jointAngles.sorted { $0.key < $1.key }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Angles en direct")
+                .font(.headline)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 12)], spacing: 12) {
+                ForEach(sortedAngles, id: \.0) { joint, angle in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(joint.localizedName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("\(angle, specifier: "%.1f")°")
+                            .font(.title3.weight(.bold))
+                    }
+                    .padding()
+                    .background(.thinMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+            }
+        }
+    }
+}
+
+private struct SessionSummaryCard: View {
+    let summary: SessionSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Rapport d'analyse")
+                .font(.headline)
+
+            HStack {
+                Label(summary.formattedDuration, systemImage: "clock")
+                Spacer()
+                Label("\(summary.frameCount) frames", systemImage: "video")
+            }
+            .font(.subheadline)
+
+            if summary.hasJointData {
+                Divider()
+                ForEach(summary.jointSummaries) { jointSummary in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(jointSummary.joint.localizedName)
+                                .font(.subheadline.weight(.semibold))
+                            Spacer()
+                            Text("\(jointSummary.movementCount) mouvements")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(jointSummary.averageDescription)
+                            .font(.body)
+                        Text(jointSummary.rangeDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(jointSummary.isoDescription)
+                            .font(.caption2)
+                            .foregroundColor(jointSummary.isoStatus.tintColor)
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+        .padding()
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private struct PermissionOverlay: View {
+    let status: AVAuthorizationStatus
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.white)
+            Text(permissionMessage)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.white)
+                .padding(.horizontal)
+        }
+        .padding(32)
+        .background(Color.black.opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+
+    private var permissionMessage: String {
+        switch status {
+        case .denied, .restricted:
+            return "L'application nécessite l'accès à la caméra pour analyser les mouvements. Activez l'autorisation dans Réglages."
+        case .notDetermined:
+            return "Autorisez l'accès à la caméra pour démarrer l'analyse."
+        default:
+            return "Caméra non disponible"
         }
     }
 }

--- a/ErgonomieApp/Views/PoseOverlayView.swift
+++ b/ErgonomieApp/Views/PoseOverlayView.swift
@@ -11,7 +11,9 @@ struct PoseOverlayView: View {
                         if let normalized = pose.jointPositions[joint] {
                             let position = CGPoint(x: normalized.x * geometry.size.width,
                                                    y: (1 - normalized.y) * geometry.size.height)
-                            JointView(name: joint.rawValue, position: position)
+                            JointView(joint: joint,
+                                      angle: pose.jointAngles[joint],
+                                      position: position)
                         }
                     }
 
@@ -40,7 +42,8 @@ struct PoseOverlayView: View {
 }
 
 private struct JointView: View {
-    let name: String
+    let joint: JointType
+    let angle: Double?
     let position: CGPoint
 
     var body: some View {
@@ -48,12 +51,20 @@ private struct JointView: View {
             Circle()
                 .fill(Color.accentColor)
                 .frame(width: 10, height: 10)
-            Text(name)
-                .font(.caption2)
-                .foregroundColor(.white)
-                .padding(4)
-                .background(Color.black.opacity(0.6))
-                .clipShape(Capsule())
+
+            VStack(spacing: 2) {
+                Text(joint.localizedName)
+                    .font(.caption2.weight(.semibold))
+                if let angle {
+                    Text("\(angle, specifier: "%.0f")°")
+                        .font(.caption2)
+                }
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(Color.black.opacity(0.55))
+            .clipShape(Capsule())
+            .foregroundColor(.white)
         }
         .position(position)
     }

--- a/ErgonomieApp/Views/SessionDetailView.swift
+++ b/ErgonomieApp/Views/SessionDetailView.swift
@@ -7,6 +7,9 @@ struct SessionDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
+                SectionHeader("Synthèse de session")
+                SessionSummarySection(summary: session.summary)
+
                 SectionHeader("Résumé ISO")
                 ForEach(session.assessments.sorted(by: { $0.jointType.rawValue < $1.jointType.rawValue }), id: \.jointType) { assessment in
                     AssessmentCard(assessment: assessment)
@@ -47,7 +50,7 @@ private struct AssessmentCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text(assessment.jointType.rawValue)
+                Text(assessment.jointType.localizedName)
                     .font(.headline)
                 Spacer()
                 Label(assessment.riskLevel.description, systemImage: assessment.riskLevel.iconName)
@@ -58,6 +61,52 @@ private struct AssessmentCard: View {
             Text("Recommandations : \(assessment.recommendations.joined(separator: ", "))")
                 .font(.footnote)
                 .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+private struct SessionSummarySection: View {
+    let summary: SessionSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Label(summary.formattedDuration, systemImage: "clock")
+                Spacer()
+                Label("\(summary.frameCount) frames", systemImage: "video")
+            }
+            .font(.subheadline)
+
+            if summary.hasJointData {
+                Divider()
+                ForEach(summary.jointSummaries) { jointSummary in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text(jointSummary.joint.localizedName)
+                                .font(.headline)
+                            Spacer()
+                            Text("\(jointSummary.movementCount) mouvements")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("Angle moyen : \(jointSummary.averageAngle, specifier: "%.1f")°")
+                            .font(.subheadline)
+                        Text(jointSummary.rangeDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(jointSummary.isoDescription)
+                            .font(.caption2)
+                            .foregroundColor(jointSummary.isoStatus.tintColor)
+                    }
+                    .padding(.vertical, 8)
+                }
+            } else {
+                Text("Aucune donnée articulatoire enregistrée.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding()
         .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))


### PR DESCRIPTION
## Summary
- prompt the user for camera authorization and start the back camera preview on launch
- add live analysis controls, real-time joint angle overlays, and permission messaging to the capture screen
- collect per-joint statistics during a session and persist rich session summaries for dashboards, reports, and exports

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68ccbd0ba60083228390b105833103cf