### PR TITLE
Improve pose orientation, stabilization, and analytics

### DIFF
--- a/ErgonomieApp/Models/PoseFrame.swift
+++ b/ErgonomieApp/Models/PoseFrame.swift
@@ -4,13 +4,32 @@ import Foundation
 typealias NormalizedPoint = CGPoint
 
 struct PoseFrame: Identifiable, Codable {
-    let id = UUID()
+    let id: UUID
     let timestamp: Date
     let jointPositions: [JointType: NormalizedPoint]
     let jointAngles: [JointType: Double]
     let repetitionEstimate: Double
     let mostCriticalJoint: JointType?
     let isoScore: Int
+    let extrapolatedJoints: Set<JointType>
+
+    init(id: UUID = UUID(),
+         timestamp: Date,
+         jointPositions: [JointType: NormalizedPoint],
+         jointAngles: [JointType: Double],
+         repetitionEstimate: Double,
+         mostCriticalJoint: JointType?,
+         isoScore: Int,
+         extrapolatedJoints: Set<JointType>) {
+        self.id = id
+        self.timestamp = timestamp
+        self.jointPositions = jointPositions
+        self.jointAngles = jointAngles
+        self.repetitionEstimate = repetitionEstimate
+        self.mostCriticalJoint = mostCriticalJoint
+        self.isoScore = isoScore
+        self.extrapolatedJoints = extrapolatedJoints
+    }
 
     var jointConnections: [(JointType, JointType)] {
         [
@@ -29,5 +48,42 @@ struct PoseFrame: Identifiable, Codable {
             (.rightHip, .rightKnee),
             (.rightKnee, .rightAnkle)
         ]
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case timestamp
+        case jointPositions
+        case jointAngles
+        case repetitionEstimate
+        case mostCriticalJoint
+        case isoScore
+        case extrapolatedJoints
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        jointPositions = try container.decode([JointType: NormalizedPoint].self, forKey: .jointPositions)
+        jointAngles = try container.decode([JointType: Double].self, forKey: .jointAngles)
+        repetitionEstimate = try container.decode(Double.self, forKey: .repetitionEstimate)
+        mostCriticalJoint = try container.decodeIfPresent(JointType.self, forKey: .mostCriticalJoint)
+        isoScore = try container.decode(Int.self, forKey: .isoScore)
+        extrapolatedJoints = try container.decodeIfPresent(Set<JointType>.self, forKey: .extrapolatedJoints) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(jointPositions, forKey: .jointPositions)
+        try container.encode(jointAngles, forKey: .jointAngles)
+        try container.encode(repetitionEstimate, forKey: .repetitionEstimate)
+        try container.encodeIfPresent(mostCriticalJoint, forKey: .mostCriticalJoint)
+        try container.encode(isoScore, forKey: .isoScore)
+        if !extrapolatedJoints.isEmpty {
+            try container.encode(extrapolatedJoints, forKey: .extrapolatedJoints)
+        }
     }
 }

--- a/ErgonomieApp/Models/PoseSession.swift
+++ b/ErgonomieApp/Models/PoseSession.swift
@@ -212,6 +212,21 @@ struct SessionSummary: Codable {
     }
 }
 
+extension SessionSummary.JointSummary.IsoStatus {
+    var severityRank: Int {
+        switch self {
+        case .critical:
+            return 3
+        case .attention:
+            return 2
+        case .compliant:
+            return 1
+        case .unknown:
+            return 0
+        }
+    }
+}
+
 struct JointAssessment: Codable {
     enum RiskLevel: String, Codable {
         case low

--- a/ErgonomieApp/Services/CaptureService.swift
+++ b/ErgonomieApp/Services/CaptureService.swift
@@ -1,18 +1,43 @@
 import AVFoundation
 import Combine
 import Foundation
+import ImageIO
+import UIKit
 
 final class CaptureService: NSObject, ObservableObject {
     @Published private(set) var isSessionRunning = false
+    @Published private(set) var imageOrientation: CGImagePropertyOrientation
 
     private(set) lazy var session = AVCaptureSession()
     private let sessionQueue = DispatchQueue(label: "capture.session.queue")
     private let sampleBufferSubject = PassthroughSubject<CMSampleBuffer, Never>()
+    private let videoOutput = AVCaptureVideoDataOutput()
+
+    private var currentVideoOrientation: AVCaptureVideoOrientation = .portrait {
+        didSet {
+            let targetOrientation = currentVideoOrientation.cgImageOrientation(for: .back)
+            DispatchQueue.main.async { [weak self] in
+                self?.imageOrientation = targetOrientation
+            }
+            applyCurrentOrientation()
+        }
+    }
 
     var isConfigured = false
 
     var sampleBufferPublisher: AnyPublisher<CMSampleBuffer, Never> {
         sampleBufferSubject.eraseToAnyPublisher()
+    }
+
+    override init() {
+        imageOrientation = AVCaptureVideoOrientation.portrait.cgImageOrientation(for: .back)
+        super.init()
+        configureOrientationMonitoring()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        UIDevice.current.endGeneratingDeviceOrientationNotifications()
     }
 
     func requestAuthorizationIfNeeded(completion: @escaping (Bool) -> Void) {
@@ -55,12 +80,13 @@ final class CaptureService: NSObject, ObservableObject {
                 session.addInput(input)
             }
 
-            let output = AVCaptureVideoDataOutput()
-            output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-            output.setSampleBufferDelegate(self, queue: sessionQueue)
-            if session.canAddOutput(output) {
-                session.addOutput(output)
+            videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+            videoOutput.alwaysDiscardsLateVideoFrames = true
+            videoOutput.setSampleBufferDelegate(self, queue: sessionQueue)
+            if session.canAddOutput(videoOutput) {
+                session.addOutput(videoOutput)
             }
+            applyCurrentOrientation()
         } catch {
             print("Erreur configuration session : \(error)")
         }
@@ -92,6 +118,87 @@ final class CaptureService: NSObject, ObservableObject {
 
 extension CaptureService: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        if connection.isVideoOrientationSupported, connection.videoOrientation != currentVideoOrientation {
+            connection.videoOrientation = currentVideoOrientation
+        }
+        if connection.isVideoMirroringSupported {
+            connection.isVideoMirrored = false
+        }
         sampleBufferSubject.send(sampleBuffer)
+    }
+}
+
+// MARK: - Orientation handling
+
+private extension CaptureService {
+    func configureOrientationMonitoring() {
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDeviceOrientationChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc func handleDeviceOrientationChange() {
+        guard let deviceOrientation = UIDevice.current.captureVideoOrientation else { return }
+        guard deviceOrientation != currentVideoOrientation else { return }
+        currentVideoOrientation = deviceOrientation
+    }
+
+    func applyCurrentOrientation() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            guard let connection = self.videoOutput.connection(with: .video) else { return }
+            if connection.isVideoOrientationSupported {
+                connection.videoOrientation = self.currentVideoOrientation
+            }
+            if connection.isVideoMirroringSupported {
+                connection.isVideoMirrored = false
+            }
+        }
+    }
+}
+
+private extension UIDevice {
+    var captureVideoOrientation: AVCaptureVideoOrientation? {
+        switch orientation {
+        case .portrait:
+            return .portrait
+        case .landscapeRight:
+            return .landscapeLeft
+        case .landscapeLeft:
+            return .landscapeRight
+        case .portraitUpsideDown:
+            return .portraitUpsideDown
+        default:
+            return nil
+        }
+    }
+}
+
+private extension AVCaptureVideoOrientation {
+    func cgImageOrientation(for position: AVCaptureDevice.Position) -> CGImagePropertyOrientation {
+        switch (self, position) {
+        case (.portrait, .back):
+            return .right
+        case (.portrait, .front):
+            return .leftMirrored
+        case (.portraitUpsideDown, .back):
+            return .left
+        case (.portraitUpsideDown, .front):
+            return .rightMirrored
+        case (.landscapeLeft, .back):
+            return .down
+        case (.landscapeLeft, .front):
+            return .upMirrored
+        case (.landscapeRight, .back):
+            return .up
+        case (.landscapeRight, .front):
+            return .downMirrored
+        @unknown default:
+            return .right
+        }
     }
 }

--- a/ErgonomieApp/ViewModels/CaptureViewModel.swift
+++ b/ErgonomieApp/ViewModels/CaptureViewModel.swift
@@ -103,8 +103,8 @@ final class CaptureViewModel: ObservableObject {
         captureService.sampleBufferPublisher
             .receive(on: DispatchQueue.global(qos: .userInitiated))
             .compactMap { CMSampleBufferGetImageBuffer($0) }
-            .flatMap { [poseEstimator] pixelBuffer in
-                poseEstimator.estimatePose(from: pixelBuffer)
+            .flatMap { [poseEstimator, captureService] pixelBuffer in
+                poseEstimator.estimatePose(from: pixelBuffer, orientation: captureService.imageOrientation)
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] pose in

--- a/ErgonomieApp/ViewModels/DashboardViewModel.swift
+++ b/ErgonomieApp/ViewModels/DashboardViewModel.swift
@@ -5,6 +5,7 @@ import Foundation
 final class DashboardViewModel: ObservableObject {
     @Published private(set) var sessions: [PoseSession] = []
     @Published private(set) var liveMetrics: LiveMetrics?
+    @Published private(set) var aggregatedInsights: AggregatedInsights?
 
     private let dataStore = DataStore.shared
     private var captureViewModel: CaptureViewModel?
@@ -23,6 +24,7 @@ final class DashboardViewModel: ObservableObject {
     func loadSessions() async {
         do {
             sessions = try await dataStore.fetchSessions()
+            updateAggregates()
         } catch {
             print("Erreur chargement sessions : \(error)")
         }
@@ -47,6 +49,18 @@ final class DashboardViewModel: ObservableObject {
         } catch {
             return ExportResult.failure("Échec export CSV : \(error.localizedDescription)")
         }
+    }
+
+    var mostRecentSession: PoseSession? {
+        sessions.sorted(by: { $0.metadata.date > $1.metadata.date }).first
+    }
+
+    func recommendations(for summary: SessionSummary) -> [AggregatedInsights.RecommendedAction] {
+        AggregatedInsights.recommendations(for: summary)
+    }
+
+    private func updateAggregates() {
+        aggregatedInsights = AggregatedInsights(sessions: sessions)
     }
 }
 
@@ -80,5 +94,264 @@ struct ExportResult {
 
     static func failure(_ message: String) -> ExportResult {
         ExportResult(isSuccess: false, message: message)
+    }
+}
+
+struct AggregatedInsights {
+    struct BodyZoneExposure: Identifiable {
+        enum BodyZone: String, CaseIterable {
+            case headAndNeck
+            case trunk
+            case leftUpperLimb
+            case rightUpperLimb
+            case leftLowerLimb
+            case rightLowerLimb
+
+            var localizedName: String {
+                switch self {
+                case .headAndNeck:
+                    return "Tête & cou"
+                case .trunk:
+                    return "Torse"
+                case .leftUpperLimb:
+                    return "Membre supérieur gauche"
+                case .rightUpperLimb:
+                    return "Membre supérieur droit"
+                case .leftLowerLimb:
+                    return "Membre inférieur gauche"
+                case .rightLowerLimb:
+                    return "Membre inférieur droit"
+                }
+            }
+        }
+
+        let zone: BodyZone
+        let criticalDuration: TimeInterval
+        let attentionDuration: TimeInterval
+        let compliantDuration: TimeInterval
+        let joints: [JointType]
+
+        var id: BodyZone { zone }
+
+        var totalDuration: TimeInterval {
+            criticalDuration + attentionDuration + compliantDuration
+        }
+
+        var dominantStatus: SessionSummary.JointSummary.IsoStatus {
+            if criticalDuration > 0 { return .critical }
+            if attentionDuration > 0 { return .attention }
+            if compliantDuration > 0 { return .compliant }
+            return .unknown
+        }
+
+        var formattedExposure: String {
+            totalDuration.formattedHoursAndMinutes
+        }
+    }
+
+    struct RecommendedAction: Identifiable {
+        let id = UUID()
+        let title: String
+        let details: String
+    }
+
+    static let defaultNormativeReferences = [
+        "ISO 11226 – Postures de travail statiques",
+        "ISO 11228-3 – Manutentions manuelles de charges",
+        "EN 1005-4 – Sécurité des machines : posture de travail",
+        "CSA Z1004 – Ergonomie au travail"
+    ]
+
+    let totalDuration: TimeInterval
+    let criticalDuration: TimeInterval
+    let attentionDuration: TimeInterval
+    let compliantDuration: TimeInterval
+    let bodyZoneExposures: [BodyZoneExposure]
+    let recurringCriticalJoints: [JointType: Int]
+    let recommendedActions: [RecommendedAction]
+    let normativeReferences: [String]
+
+    init(sessions: [PoseSession]) {
+        totalDuration = sessions.reduce(0) { $0 + $1.summary.duration }
+
+        var criticalDuration: TimeInterval = 0
+        var attentionDuration: TimeInterval = 0
+        var compliantDuration: TimeInterval = 0
+        var recurringCriticalJoints: [JointType: Int] = [:]
+        var zoneAccumulators: [BodyZoneExposure.BodyZone: (critical: TimeInterval, attention: TimeInterval, compliant: TimeInterval, joints: Set<JointType>)] = [:]
+
+        for session in sessions {
+            let summary = session.summary
+            let duration = summary.duration
+
+            var hasCritical = false
+            var hasAttention = false
+
+            for jointSummary in summary.jointSummaries {
+                let zone = AggregatedInsights.bodyZone(for: jointSummary.joint)
+                var accumulator = zoneAccumulators[zone, default: (0, 0, 0, [])]
+                accumulator.joints.insert(jointSummary.joint)
+
+                switch jointSummary.isoStatus {
+                case .critical:
+                    accumulator.critical += duration
+                    recurringCriticalJoints[jointSummary.joint, default: 0] += 1
+                    hasCritical = true
+                case .attention:
+                    accumulator.attention += duration
+                    hasAttention = true
+                case .compliant:
+                    accumulator.compliant += duration
+                case .unknown:
+                    break
+                }
+
+                zoneAccumulators[zone] = accumulator
+            }
+
+            if hasCritical {
+                criticalDuration += duration
+            } else if hasAttention {
+                attentionDuration += duration
+            } else if !summary.jointSummaries.isEmpty {
+                compliantDuration += duration
+            }
+        }
+
+        self.criticalDuration = criticalDuration
+        self.attentionDuration = attentionDuration
+        self.compliantDuration = compliantDuration
+        self.recurringCriticalJoints = recurringCriticalJoints
+
+        bodyZoneExposures = BodyZoneExposure.BodyZone.allCases.map { zone in
+            let accumulator = zoneAccumulators[zone, default: (0, 0, 0, [])]
+            return BodyZoneExposure(
+                zone: zone,
+                criticalDuration: accumulator.critical,
+                attentionDuration: accumulator.attention,
+                compliantDuration: accumulator.compliant,
+                joints: Array(accumulator.joints).sorted()
+            )
+        }
+
+        recommendedActions = AggregatedInsights.buildRecommendedActions(
+            criticalDuration: criticalDuration,
+            attentionDuration: attentionDuration,
+            recurringCriticalJoints: recurringCriticalJoints
+        )
+
+        normativeReferences = AggregatedInsights.defaultNormativeReferences
+    }
+
+    static func recommendations(for summary: SessionSummary) -> [RecommendedAction] {
+        let criticalJoints = summary.jointSummaries.filter { $0.isoStatus == .critical }
+        let attentionJoints = summary.jointSummaries.filter { $0.isoStatus == .attention }
+
+        var actions: [RecommendedAction] = []
+
+        if !criticalJoints.isEmpty {
+            let names = criticalJoints.map { $0.joint.localizedName }.joined(separator: ", ")
+            actions.append(
+                RecommendedAction(
+                    title: "Corriger immédiatement les postures critiques",
+                    details: "Les articulations \(names) dépassent les seuils critiques ISO. Mettre en place des ajustements de poste ou une rotation des tâches sous 7 jours."
+                )
+            )
+        }
+
+        if !attentionJoints.isEmpty {
+            let names = attentionJoints.map { $0.joint.localizedName }.joined(separator: ", ")
+            actions.append(
+                RecommendedAction(
+                    title: "Plan d'amélioration ciblé",
+                    details: "Suivre \(names) avec des micro-pauses et un coaching postural en s'appuyant sur les référentiels ISO 11226/11228."
+                )
+            )
+        }
+
+        if actions.isEmpty {
+            actions.append(
+                RecommendedAction(
+                    title: "Maintenir la vigilance",
+                    details: "Aucune alerte critique détectée. Consolider les bonnes pratiques et planifier une nouvelle observation d'ici 30 jours."
+                )
+            )
+        }
+
+        return actions
+    }
+
+    private static func bodyZone(for joint: JointType) -> BodyZoneExposure.BodyZone {
+        switch joint {
+        case .head, .neck:
+            return .headAndNeck
+        case .torso:
+            return .trunk
+        case .leftShoulder, .leftElbow, .leftWrist:
+            return .leftUpperLimb
+        case .rightShoulder, .rightElbow, .rightWrist:
+            return .rightUpperLimb
+        case .leftHip, .leftKnee, .leftAnkle:
+            return .leftLowerLimb
+        case .rightHip, .rightKnee, .rightAnkle:
+            return .rightLowerLimb
+        }
+    }
+
+    private static func buildRecommendedActions(criticalDuration: TimeInterval,
+                                                 attentionDuration: TimeInterval,
+                                                 recurringCriticalJoints: [JointType: Int]) -> [RecommendedAction] {
+        var actions: [RecommendedAction] = []
+
+        if criticalDuration > 0 {
+            actions.append(
+                RecommendedAction(
+                    title: "Déployer un plan correctif prioritaire",
+                    details: "\(criticalDuration.formattedHoursAndMinutes) passées en zone critique. Revoir l'organisation du poste, l'aide mécanique et la formation gestes & postures."
+                )
+            )
+        }
+
+        if attentionDuration > 0 {
+            actions.append(
+                RecommendedAction(
+                    title: "Mettre en place un suivi renforcé",
+                    details: "\(attentionDuration.formattedHoursAndMinutes) en zone de vigilance. Instaurer des pauses actives et valider les réglages ergonomiques."
+                )
+            )
+        }
+
+        if !recurringCriticalJoints.isEmpty {
+            let topJoints = recurringCriticalJoints.sorted { $0.value > $1.value }.prefix(3)
+            let description = topJoints
+                .map { "\($0.key.localizedName) (\($0.value)×)" }
+                .joined(separator: ", ")
+            actions.append(
+                RecommendedAction(
+                    title: "Cibler les zones récurrentes",
+                    details: "Les articulations les plus sollicitées : \(description). Prioriser des mesures correctives sur ces segments."
+                )
+            )
+        }
+
+        if actions.isEmpty {
+            actions.append(
+                RecommendedAction(
+                    title: "Poursuivre la surveillance",
+                    details: "Aucune dérive majeure observée. Conserver le dispositif de suivi et sensibiliser les opérateurs."
+                )
+            )
+        }
+
+        return actions
+    }
+}
+
+extension TimeInterval {
+    var formattedHoursAndMinutes: String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .abbreviated
+        formatter.allowedUnits = self >= 3600 ? [.hour, .minute] : [.minute, .second]
+        return formatter.string(from: self) ?? "0m"
     }
 }

--- a/ErgonomieApp/Views/DashboardView.swift
+++ b/ErgonomieApp/Views/DashboardView.swift
@@ -8,12 +8,25 @@ struct DashboardView: View {
             List {
                 Section("Session en cours") {
                     if let metrics = dashboardViewModel.liveMetrics {
-                        MetricRow(title: "Fréquence répétitions", value: metrics.repetitionFrequency)
-                        MetricRow(title: "Posture critique", value: metrics.criticalPostureDescription)
-                        MetricRow(title: "Score ISO", value: metrics.isoScoreDescription)
+                        LiveMetricsSection(metrics: metrics)
                     } else {
                         Text("Aucune donnée en direct")
                             .foregroundColor(.secondary)
+                    }
+                }
+
+                if let summary = dashboardViewModel.mostRecentSession?.summary {
+                    Section("Cartographie des risques") {
+                        RiskMapView(summary: summary)
+                            .frame(height: 280)
+                            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                            .listRowBackground(Color.clear)
+                    }
+                }
+
+                if let insights = dashboardViewModel.aggregatedInsights {
+                    Section("Analyse stratégique") {
+                        AggregatedInsightsSection(insights: insights)
                     }
                 }
 
@@ -30,7 +43,17 @@ struct DashboardView: View {
                         }
                     }
                 }
+
+                if let insights = dashboardViewModel.aggregatedInsights {
+                    Section("Référentiels ergonomiques") {
+                        ForEach(insights.normativeReferences, id: \.self) { reference in
+                            Label(reference, systemImage: "checkmark.seal")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
             }
+            .listStyle(.insetGrouped)
             .navigationTitle("Tableau de bord")
             .task {
                 await dashboardViewModel.loadSessions()
@@ -39,16 +62,163 @@ struct DashboardView: View {
     }
 }
 
+private struct LiveMetricsSection: View {
+    let metrics: LiveMetrics
+
+    var body: some View {
+        VStack(spacing: 12) {
+            MetricRow(title: "Fréquence répétitions", value: metrics.repetitionFrequency, icon: "gobackward")
+            MetricRow(title: "Posture critique", value: metrics.criticalPostureDescription, icon: "figure.wave")
+            MetricRow(title: "Score ISO", value: metrics.isoScoreDescription, icon: "chart.bar.doc.horizontal")
+        }
+        .padding(.vertical, 8)
+    }
+}
+
 private struct MetricRow: View {
     let title: String
     let value: String
+    let icon: String
 
     var body: some View {
-        HStack {
-            Text(title)
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundColor(.accentColor)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Text(value)
+                    .font(.headline)
+            }
             Spacer()
-            Text(value)
-                .bold()
         }
+    }
+}
+
+private struct AggregatedInsightsSection: View {
+    let insights: AggregatedInsights
+
+    private var exposures: [AggregatedInsights.BodyZoneExposure] {
+        insights.bodyZoneExposures
+            .filter { $0.totalDuration > 0 }
+            .sorted { lhs, rhs in
+                if lhs.dominantStatus.severityRank == rhs.dominantStatus.severityRank {
+                    return lhs.totalDuration > rhs.totalDuration
+                }
+                return lhs.dominantStatus.severityRank > rhs.dominantStatus.severityRank
+            }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ViewThatFits {
+                HStack(spacing: 16) {
+                    DurationBadge(title: "Durée critique", value: insights.criticalDuration.formattedHoursAndMinutes, tint: .red)
+                    DurationBadge(title: "Zone de vigilance", value: insights.attentionDuration.formattedHoursAndMinutes, tint: .orange)
+                    DurationBadge(title: "Conforme", value: insights.compliantDuration.formattedHoursAndMinutes, tint: .green)
+                }
+                VStack(spacing: 12) {
+                    DurationBadge(title: "Durée critique", value: insights.criticalDuration.formattedHoursAndMinutes, tint: .red)
+                    DurationBadge(title: "Zone de vigilance", value: insights.attentionDuration.formattedHoursAndMinutes, tint: .orange)
+                    DurationBadge(title: "Conforme", value: insights.compliantDuration.formattedHoursAndMinutes, tint: .green)
+                }
+            }
+
+            if !exposures.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Zones sensibles récurrentes")
+                        .font(.headline)
+                    ForEach(exposures) { exposure in
+                        BodyZoneExposureRow(exposure: exposure)
+                    }
+                }
+            }
+
+            if !insights.recommendedActions.isEmpty {
+                Divider()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Recommandations inspirées de Nawo Live")
+                        .font(.headline)
+                    ForEach(insights.recommendedActions) { action in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(action.title)
+                                .font(.subheadline.weight(.semibold))
+                            Text(action.details)
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 6)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct DurationBadge: View {
+    let title: String
+    let value: String
+    let tint: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.headline)
+                .foregroundColor(tint)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+}
+
+private struct BodyZoneExposureRow: View {
+    let exposure: AggregatedInsights.BodyZoneExposure
+
+    private var tint: Color {
+        switch exposure.dominantStatus {
+        case .critical:
+            return .red
+        case .attention:
+            return .orange
+        case .compliant:
+            return .green
+        case .unknown:
+            return .gray
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(exposure.zone.localizedName)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text(exposure.dominantStatus.description)
+                    .font(.caption)
+                    .foregroundColor(tint)
+            }
+            Text("Exposition cumulée : \(exposure.formattedExposure)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            if !exposure.joints.isEmpty {
+                Text("Articulations suivies : \(exposure.joints.map { $0.localizedName }.joined(separator: ", "))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.tertiarySystemBackground))
+        )
     }
 }

--- a/ErgonomieApp/Views/PoseOverlayView.swift
+++ b/ErgonomieApp/Views/PoseOverlayView.swift
@@ -2,41 +2,68 @@ import SwiftUI
 
 struct PoseOverlayView: View {
     let pose: PoseFrame?
+    var contentInset: CGFloat = 12
+    var jointColor: Color = .accentColor
+
+    private var extrapolatedColor: Color {
+        jointColor.opacity(0.4)
+    }
 
     var body: some View {
         GeometryReader { geometry in
+            let drawingWidth = max(geometry.size.width - contentInset * 2, 0)
+            let drawingHeight = max(geometry.size.height - contentInset * 2, 0)
+
             ZStack {
                 if let pose {
-                    ForEach(pose.jointPositions.keys.sorted(), id: \.self) { joint in
-                        if let normalized = pose.jointPositions[joint] {
-                            let position = CGPoint(x: normalized.x * geometry.size.width,
-                                                   y: (1 - normalized.y) * geometry.size.height)
-                            JointView(joint: joint,
-                                      angle: pose.jointAngles[joint],
-                                      position: position)
-                        }
-                    }
-
                     ForEach(pose.jointConnections, id: \.self) { connection in
                         if let start = pose.jointPositions[connection.0],
                            let end = pose.jointPositions[connection.1] {
-                            let startPoint = CGPoint(x: start.x * geometry.size.width,
-                                                     y: (1 - start.y) * geometry.size.height)
-                            let endPoint = CGPoint(x: end.x * geometry.size.width,
-                                                   y: (1 - end.y) * geometry.size.height)
+                            let startPoint = CGPoint(
+                                x: contentInset + start.x * drawingWidth,
+                                y: contentInset + (1 - start.y) * drawingHeight
+                            )
+                            let endPoint = CGPoint(
+                                x: contentInset + end.x * drawingWidth,
+                                y: contentInset + (1 - end.y) * drawingHeight
+                            )
+
+                            let usesCache = pose.extrapolatedJoints.contains(connection.0) ||
+                                pose.extrapolatedJoints.contains(connection.1)
+
                             Path { path in
                                 path.move(to: startPoint)
                                 path.addLine(to: endPoint)
                             }
-                            .stroke(Color.orange, lineWidth: 2)
+                            .stroke(usesCache ? extrapolatedColor : jointColor, lineWidth: 2)
+                        }
+                    }
+
+                    ForEach(pose.jointPositions.keys.sorted(), id: \.self) { joint in
+                        if let normalized = pose.jointPositions[joint] {
+                            let position = CGPoint(
+                                x: contentInset + normalized.x * drawingWidth,
+                                y: contentInset + (1 - normalized.y) * drawingHeight
+                            )
+                            let isExtrapolated = pose.extrapolatedJoints.contains(joint)
+
+                            JointView(
+                                joint: joint,
+                                angle: pose.jointAngles[joint],
+                                position: position,
+                                isExtrapolated: isExtrapolated,
+                                jointColor: jointColor,
+                                extrapolatedColor: extrapolatedColor
+                            )
                         }
                     }
                 } else {
                     Text("Aucune pose détectée")
+                        .font(.caption)
                         .foregroundColor(.secondary)
                 }
             }
-            .animation(.easeInOut, value: pose?.id)
+            .animation(.easeInOut(duration: 0.2), value: pose?.id)
         }
     }
 }
@@ -45,12 +72,19 @@ private struct JointView: View {
     let joint: JointType
     let angle: Double?
     let position: CGPoint
+    let isExtrapolated: Bool
+    let jointColor: Color
+    let extrapolatedColor: Color
 
     var body: some View {
         VStack(spacing: 4) {
             Circle()
-                .fill(Color.accentColor)
+                .fill(isExtrapolated ? extrapolatedColor : jointColor)
                 .frame(width: 10, height: 10)
+                .overlay(
+                    Circle()
+                        .stroke(Color.white.opacity(0.6), lineWidth: 1)
+                )
 
             VStack(spacing: 2) {
                 Text(joint.localizedName)
@@ -58,13 +92,17 @@ private struct JointView: View {
                 if let angle {
                     Text("\(angle, specifier: "%.0f")°")
                         .font(.caption2)
+                } else if isExtrapolated {
+                    Text("Stabilisé")
+                        .font(.caption2)
                 }
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 4)
-            .background(Color.black.opacity(0.55))
+            .background(.thinMaterial)
             .clipShape(Capsule())
             .foregroundColor(.white)
+            .shadow(color: Color.black.opacity(0.2), radius: 2, x: 0, y: 1)
         }
         .position(position)
     }

--- a/ErgonomieApp/Views/ReportsView.swift
+++ b/ErgonomieApp/Views/ReportsView.swift
@@ -3,21 +3,97 @@ import SwiftUI
 struct ReportsView: View {
     @EnvironmentObject private var dashboardViewModel: DashboardViewModel
     @State private var exportResult: ExportResult?
+    @State private var selectedSessionID: PoseSession.ID?
+    @State private var includeHeatmap = true
+    @State private var includeActionPlan = true
+    @State private var includeRawAngles = false
+
+    private var selectedSession: PoseSession? {
+        if let id = selectedSessionID {
+            return dashboardViewModel.sessions.first(where: { $0.id == id })
+        }
+        return dashboardViewModel.mostRecentSession
+    }
+
+    private var normativeReferences: [String] {
+        dashboardViewModel.aggregatedInsights?.normativeReferences ?? AggregatedInsights.defaultNormativeReferences
+    }
 
     var body: some View {
         NavigationView {
-            List {
+            Form {
+                Section("Sélection de session") {
+                    if dashboardViewModel.sessions.isEmpty {
+                        Text("Aucune session enregistrée.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        Picker("Session", selection: $selectedSessionID) {
+                            Text("Plus récente")
+                                .tag(PoseSession.ID?.none)
+                            ForEach(dashboardViewModel.sessions) { session in
+                                Text("\(session.metadata.taskName) – \(session.metadata.formattedDate)")
+                                    .tag(PoseSession.ID?.some(session.id))
+                            }
+                        }
+                        Toggle("Inclure la cartographie", isOn: $includeHeatmap)
+                        Toggle("Inclure le plan d'action", isOn: $includeActionPlan)
+                        Toggle("Joindre les angles bruts", isOn: $includeRawAngles)
+                    }
+                }
+
+                if let session = selectedSession {
+                    if includeHeatmap {
+                        Section("Cartographie ergonomique") {
+                            RiskMapView(summary: session.summary)
+                                .frame(height: 280)
+                                .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                                .listRowBackground(Color.clear)
+                        }
+                    }
+
+                    if includeActionPlan {
+                        Section("Plan d'action prioritaire") {
+                            ActionChecklistView(
+                                session: session,
+                                recommendations: dashboardViewModel.recommendations(for: session.summary),
+                                normativeReferences: normativeReferences
+                            )
+                        }
+                    }
+
+                    Section("Synthèse ISO") {
+                        ForEach(session.summary.jointSummaries.filter { $0.isoStatus != .compliant }) { jointSummary in
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(jointSummary.joint.localizedName)
+                                    .font(.subheadline.weight(.semibold))
+                                Text(jointSummary.isoDescription)
+                                    .font(.caption)
+                                    .foregroundColor(jointSummary.isoStatus.tintColor)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        if includeRawAngles {
+                            NavigationLink("Consulter les angles détaillés") {
+                                SessionDetailView(session: session)
+                            }
+                        }
+                    }
+                }
+
                 Section("Exporter") {
                     Button("Exporter le dernier rapport PDF") {
                         Task {
                             exportResult = await dashboardViewModel.exportLatestReport()
                         }
                     }
+                    .disabled(dashboardViewModel.sessions.isEmpty)
+
                     Button("Exporter les données CSV") {
                         Task {
                             exportResult = await dashboardViewModel.exportCSV()
                         }
                     }
+                    .disabled(dashboardViewModel.sessions.isEmpty)
                 }
 
                 if let exportResult {
@@ -28,6 +104,60 @@ struct ReportsView: View {
                 }
             }
             .navigationTitle("Rapports")
+            .task {
+                await dashboardViewModel.loadSessions()
+            }
         }
+    }
+}
+
+private struct ActionChecklistView: View {
+    let session: PoseSession
+    let recommendations: [AggregatedInsights.RecommendedAction]
+    let normativeReferences: [String]
+
+    private var duration: String {
+        session.summary.formattedDuration
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Session analysée : \(session.metadata.taskName)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("Durée observée : \(duration)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Actions recommandées")
+                    .font(.headline)
+                ForEach(recommendations) { recommendation in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(recommendation.title)
+                            .font(.subheadline.weight(.semibold))
+                        Text(recommendation.details)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color(.tertiarySystemBackground))
+                    )
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Références normatives")
+                    .font(.headline)
+                ForEach(normativeReferences, id: \.self) { reference in
+                    Label(reference, systemImage: "book")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
     }
 }

--- a/ErgonomieApp/Views/RiskMapView.swift
+++ b/ErgonomieApp/Views/RiskMapView.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+struct RiskMapView: View {
+    let summary: SessionSummary
+
+    private var jointSummaries: [JointType: SessionSummary.JointSummary] {
+        Dictionary(uniqueKeysWithValues: summary.jointSummaries.map { ($0.joint, $0) })
+    }
+
+    private var highlightedJoints: [SessionSummary.JointSummary] {
+        Array(
+            summary.jointSummaries
+                .filter { $0.isoStatus != .compliant && $0.isoStatus != .unknown }
+                .sorted { $0.isoStatus.severityRank > $1.isoStatus.severityRank }
+                .prefix(3)
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GeometryReader { geometry in
+                let size = geometry.size
+                ZStack {
+                    ForEach(BodySegment.allCases, id: \.self) { segment in
+                        let descriptor = segment.descriptor(in: size)
+                        let status = status(for: segment)
+                        let color = color(for: status)
+
+                        segment.shape
+                            .fill(color)
+                            .frame(width: descriptor.size.width, height: descriptor.size.height)
+                            .position(descriptor.center)
+                            .overlay(
+                                segment.label
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundColor(.white.opacity(0.9))
+                                    .padding(4)
+                                    .background(Color.black.opacity(0.35))
+                                    .clipShape(Capsule())
+                                    .padding(.top, segment == .head ? 8 : 0),
+                                alignment: .top
+                            )
+                    }
+                }
+            }
+            .aspectRatio(3 / 4, contentMode: .fit)
+            .frame(maxWidth: .infinity)
+
+            if !highlightedJoints.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Segments à surveiller")
+                        .font(.subheadline.weight(.semibold))
+                    ForEach(highlightedJoints, id: \.joint) { summary in
+                        HStack {
+                            Label(summary.joint.localizedName, systemImage: "exclamationmark.triangle.fill")
+                                .foregroundColor(color(for: summary.isoStatus))
+                            Spacer()
+                            Text(summary.isoDescription)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color(.tertiarySystemBackground))
+                        )
+                    }
+                }
+            }
+
+            RiskLegend()
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private func status(for segment: BodySegment) -> SessionSummary.JointSummary.IsoStatus {
+        let joints = segment.joints
+        let statuses = joints.compactMap { jointSummaries[$0]?.isoStatus }
+        guard let maxStatus = statuses.max(by: { $0.severityRank < $1.severityRank }) else {
+            return .unknown
+        }
+        return maxStatus
+    }
+
+    private func color(for status: SessionSummary.JointSummary.IsoStatus) -> Color {
+        switch status {
+        case .critical:
+            return Color.red.opacity(0.75)
+        case .attention:
+            return Color.orange.opacity(0.7)
+        case .compliant:
+            return Color.green.opacity(0.45)
+        case .unknown:
+            return Color.gray.opacity(0.3)
+        }
+    }
+}
+
+private struct RiskLegend: View {
+    var body: some View {
+        ViewThatFits {
+            HStack(spacing: 12) {
+                LegendItem(color: .red.opacity(0.75), title: "Critique", subtitle: "Action immédiate")
+                LegendItem(color: .orange.opacity(0.7), title: "Surveillance", subtitle: "Ajustements rapides")
+                LegendItem(color: .green.opacity(0.45), title: "Conforme", subtitle: "Dans la norme ISO")
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                LegendItem(color: .red.opacity(0.75), title: "Critique", subtitle: "Action immédiate")
+                LegendItem(color: .orange.opacity(0.7), title: "Surveillance", subtitle: "Ajustements rapides")
+                LegendItem(color: .green.opacity(0.45), title: "Conforme", subtitle: "Dans la norme ISO")
+            }
+        }
+    }
+}
+
+private struct LegendItem: View {
+    let color: Color
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(color)
+                .frame(width: 16, height: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.tertiarySystemBackground))
+        )
+    }
+}
+
+private enum BodySegment: CaseIterable {
+    case head
+    case neck
+    case torso
+    case leftArm
+    case rightArm
+    case leftLeg
+    case rightLeg
+
+    var joints: [JointType] {
+        switch self {
+        case .head:
+            return [.head]
+        case .neck:
+            return [.neck]
+        case .torso:
+            return [.torso, .leftHip, .rightHip]
+        case .leftArm:
+            return [.leftShoulder, .leftElbow, .leftWrist]
+        case .rightArm:
+            return [.rightShoulder, .rightElbow, .rightWrist]
+        case .leftLeg:
+            return [.leftHip, .leftKnee, .leftAnkle]
+        case .rightLeg:
+            return [.rightHip, .rightKnee, .rightAnkle]
+        }
+    }
+
+    var label: Text {
+        switch self {
+        case .head:
+            return Text("Tête")
+        case .neck:
+            return Text("Cou")
+        case .torso:
+            return Text("Torse")
+        case .leftArm:
+            return Text("Bras G")
+        case .rightArm:
+            return Text("Bras D")
+        case .leftLeg:
+            return Text("Jambe G")
+        case .rightLeg:
+            return Text("Jambe D")
+        }
+    }
+
+    var shape: AnyShape {
+        switch self {
+        case .head:
+            return AnyShape(Circle())
+        case .neck:
+            return AnyShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        case .torso:
+            return AnyShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        case .leftArm, .rightArm:
+            return AnyShape(Capsule())
+        case .leftLeg, .rightLeg:
+            return AnyShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+    }
+
+    func descriptor(in size: CGSize) -> (size: CGSize, center: CGPoint) {
+        let width = size.width
+        let height = size.height
+
+        switch self {
+        case .head:
+            return (CGSize(width: width * 0.22, height: height * 0.18), CGPoint(x: width / 2, y: height * 0.18))
+        case .neck:
+            return (CGSize(width: width * 0.12, height: height * 0.08), CGPoint(x: width / 2, y: height * 0.3))
+        case .torso:
+            return (CGSize(width: width * 0.32, height: height * 0.34), CGPoint(x: width / 2, y: height * 0.52))
+        case .leftArm:
+            return (CGSize(width: width * 0.18, height: height * 0.32), CGPoint(x: width * 0.23, y: height * 0.48))
+        case .rightArm:
+            return (CGSize(width: width * 0.18, height: height * 0.32), CGPoint(x: width * 0.77, y: height * 0.48))
+        case .leftLeg:
+            return (CGSize(width: width * 0.2, height: height * 0.36), CGPoint(x: width * 0.35, y: height * 0.82))
+        case .rightLeg:
+            return (CGSize(width: width * 0.2, height: height * 0.36), CGPoint(x: width * 0.65, y: height * 0.82))
+        }
+    }
+}
+
+private struct AnyShape: InsettableShape {
+    private let _path: (CGRect) -> Path
+    private let _inset: (CGFloat) -> AnyShape
+
+    init<S: InsettableShape>(_ shape: S) {
+        _path = { rect in shape.path(in: rect) }
+        _inset = { amount in AnyShape(shape.inset(by: amount)) }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        _path(rect)
+    }
+
+    func inset(by amount: CGFloat) -> AnyShape {
+        _inset(amount)
+    }
+}

--- a/ErgonomieApp/Views/SessionDetailView.swift
+++ b/ErgonomieApp/Views/SessionDetailView.swift
@@ -10,6 +10,10 @@ struct SessionDetailView: View {
                 SectionHeader("Synthèse de session")
                 SessionSummarySection(summary: session.summary)
 
+                SectionHeader("Cartographie posturale")
+                RiskMapView(summary: session.summary)
+                    .frame(height: 280)
+
                 SectionHeader("Résumé ISO")
                 ForEach(session.assessments.sorted(by: { $0.jointType.rawValue < $1.jointType.rawValue }), id: \.jointType) { assessment in
                     AssessmentCard(assessment: assessment)


### PR DESCRIPTION
## Summary
- force the capture pipeline to respect device orientation and present a compact skeleton widget in the lower-right corner of the live view
- stabilize pose detection by caching low-confidence joints, smoothing coordinates, and flagging extrapolated points in the overlay
- add Nawo Live-inspired risk cartography, aggregated insights, and guided report composition backed by ISO references

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68d03b1abe488322970adfb6a07e8466